### PR TITLE
Add publish github action.

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,8 @@
 name: Publish Crate
 
 on:
-  push:
-    tags:
-      - '*'  # Trigger when a tag is created
+  release:
+    types: [published]
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,30 @@
+name: Publish Crate
+
+on:
+  push:
+    tags:
+        - '*'  # Trigger when a tag is created
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  publish:
+    name: Publish to Crates.io
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        toolchain:
+          - stable
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Rust toolchain
+        run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
+      - name: Build Release
+        run: cargo build --release --verbose
+      - name: Test
+        run: cargo test --verbose
+      - name: Publish
+        run: cargo publish --token ${{ secrets.CRATES_IO_TOKEN }}
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,6 +23,8 @@ jobs:
         run: cargo build --release --verbose
       - name: Test
         run: cargo test --verbose
+      - name: Docs
+        run: cargo doc --verbose
       - name: Publish
         run: cargo publish --token ${{ secrets.CRATES_IO_TOKEN }}
         env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,7 +3,7 @@ name: Publish Crate
 on:
   push:
     tags:
-        - '*'  # Trigger when a tag is created
+      - '*'  # Trigger when a tag is created
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,6 +26,6 @@ jobs:
       - name: Docs
         run: cargo doc --verbose
       - name: Publish
-        run: cargo publish --token ${{ secrets.CRATES_IO_TOKEN }}
+        run: cargo publish
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}


### PR DESCRIPTION
## motivation

automate the publishing step in a cloud environment with a consistent build output

## changes

* adds a github step whenever a tag is created. we will create a github "release" and tag together in one step.
* added `CRATES_IO_TOKEN` to the repository's secrets

<img width="1094" alt="Screenshot 2024-05-14 at 10 58 02 AM" src="https://github.com/Eppo-exp/rust-sdk/assets/57361/ff1c10e2-2ebf-4ba6-99aa-c9136b439389">
