### PR TITLE
chore: dump MSRV from 1.76.0 down to 1.65.0

### DIFF
--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -1,0 +1,23 @@
+name: Verify MSRV version
+
+on:
+  push:
+  pull_request:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  verify_msrv:
+    name: Verify MSRV version
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        toolchain:
+          - stable
+
+    steps:
+      - uses: actions/checkout@v3
+      - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
+      - run: cargo install cargo-msrv
+      - run: cargo msrv verify

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/Eppo-exp/rust-sdk"
 license = "MIT"
 keywords = ["eppo", "feature-flags"]
 categories = ["config"]
-rust-version = "1.71.1"
+rust-version = "1.70.0"
 
 [dependencies]
 chrono = { version = "0.4.38", features = ["serde"] }
@@ -28,4 +28,4 @@ url = "2.5.0"
 name = "simple"
 
 [dev-dependencies]
-env_logger = { version = "0.11.3", features = ["unstable-kv"] }
+env_logger = { version = "0.11.3", default-features = false, features = ["unstable-kv"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/Eppo-exp/rust-sdk"
 license = "MIT"
 keywords = ["eppo", "feature-flags"]
 categories = ["config"]
+rust-version = "1.76.0"
 
 [dependencies]
 chrono = { version = "0.4.38", features = ["serde"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/Eppo-exp/rust-sdk"
 license = "MIT"
 keywords = ["eppo", "feature-flags"]
 categories = ["config"]
-rust-version = "1.76.0"
+rust-version = "1.71.1"
 
 [dependencies]
 chrono = { version = "0.4.38", features = ["serde"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/Eppo-exp/rust-sdk"
 license = "MIT"
 keywords = ["eppo", "feature-flags"]
 categories = ["config"]
-rust-version = "1.70.0"
+rust-version = "1.65.0"
 
 [dependencies]
 chrono = { version = "0.4.38", features = ["serde"] }

--- a/src/client.rs
+++ b/src/client.rs
@@ -110,16 +110,19 @@ impl<'a> Client<'a> {
             return Ok(None);
         };
 
-        let evaluation = configuration
-            .eval_flag(flag_key, subject_key, subject_attributes, &Md5Sharder)
-            .inspect_err(|err| {
-                log::warn!(target: "eppo",
-                    flag_key,
-                    subject_key,
-                    subject_attributes:serde;
-                    "error occurred while evaluating a flag: {:?}", err,
-                );
-            })?;
+        let evaluation = match configuration
+            .eval_flag(flag_key, subject_key, subject_attributes, &Md5Sharder) {
+                Ok(result) => result,
+                Err(err) => {
+                    log::warn!(target: "eppo",
+                               flag_key,
+                               subject_key,
+                               subject_attributes:serde;
+                               "error occurred while evaluating a flag: {:?}", err,
+                    );
+                    return Err(err);
+                },
+            };
 
         log::trace!(target: "eppo",
                     flag_key,

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -126,8 +126,8 @@ impl Allocation {
     }
 
     fn is_allowed_by_time(&self, now: Timestamp) -> bool {
-        let forbidden =
-            self.start_at.is_some_and(|t| now < t) || self.end_at.is_some_and(|t| now > t);
+        let forbidden = matches!(self.start_at, Some(t) if now < t)
+            || matches!(self.end_at, Some(t) if now > t);
         !forbidden
     }
 

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -128,7 +128,7 @@ impl Operator {
 
             Self::IsNull => {
                 let is_null =
-                    attribute.is_none() || attribute.is_some_and(|v| v == &AttributeValue::Null);
+                    attribute.is_none() || matches!(attribute, Some(&AttributeValue::Null));
                 match condition_value {
                     ConditionValue::Single(Value::Boolean(true)) => Some(is_null),
                     ConditionValue::Single(Value::Boolean(false)) => Some(!is_null),


### PR DESCRIPTION
Specify Minimum Supported Rust Version and dump it down to 1.65.0.

Best reviewed by commit. (Also better to merge or rebase instead of squashing.)