### PR TITLE
chore: Cache cargo-msrv tool

### DIFF
--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -18,6 +18,20 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/bin
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/git/db
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
       - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
-      - run: cargo install cargo-msrv
+      - run: |
+          if ! command -v cargo-msrv &> /dev/null
+          then
+              cargo install cargo-msrv --locked
+          fi
       - run: cargo msrv verify

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -2,6 +2,8 @@ name: Verify MSRV version
 
 on:
   push:
+    branches:
+      - main
   pull_request:
 
 env:


### PR DESCRIPTION
## observation

* Running the `Verify MSRV version` tasks takes ~5 minutes.
* pushes to a pull request branch runs the task twice (once for the PR and once for any `push`)

Logs: https://github.com/Eppo-exp/rust-sdk/actions/runs/9117036192/job/25067006061?pr=5

## description

* caches dependencies of `cargo-msrv` and the `cargo-msrv` binary
* checks if `cargo-msrv` is already installed and uses it
* runs the MSRV task once for a PR and separately on push to `main`

## testing

* Ran verify MSRV version task - it was uncached
* Re-run and verified that the tool is cached, went quickly to `verify` step - https://github.com/Eppo-exp/rust-sdk/actions/runs/9117209060/job/25067771911