### PR TITLE
[ruby] fix gem install to use eppo_core from crates.io

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,3 @@
 
 /sdk-test-data/
 node_modules
-ruby-sdk/eppo-server-sdk-0.3.0.gem

--- a/ruby-sdk/.cargo/config.toml
+++ b/ruby-sdk/.cargo/config.toml
@@ -1,0 +1,3 @@
+[patch.crates-io]
+# Local override for development.
+eppo_core = { path = '../eppo_core' }

--- a/ruby-sdk/.gitignore
+++ b/ruby-sdk/.gitignore
@@ -12,6 +12,7 @@
 *.a
 mkmf.log
 target/
+*.gem
 
 # rspec failure tracking
 .rspec_status

--- a/ruby-sdk/Cargo.lock
+++ b/ruby-sdk/Cargo.lock
@@ -295,7 +295,7 @@ dependencies = [
 
 [[package]]
 name = "eppo_core"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "chrono",
  "derive_more",

--- a/ruby-sdk/eppo-server-sdk.gemspec
+++ b/ruby-sdk/eppo-server-sdk.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.files = IO.popen(%w[git ls-files -z], chdir: __dir__, err: IO::NULL) do |ls|
     ls.readlines("\x0", chomp: true).reject do |f|
       (f == gemspec) ||
-        f.start_with?(*%w[bin/ test/ spec/ features/ .git .github appveyor Gemfile])
+        f.start_with?(*%w[bin/ test/ spec/ features/ .cargo/ .git/ .github/ appveyor Gemfile])
     end
   end
   spec.bindir = "exe"

--- a/ruby-sdk/ext/eppo_rb/Cargo.toml
+++ b/ruby-sdk/ext/eppo_rb/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 env_logger = { version = "0.11.3", features = ["unstable-kv"] }
-eppo_core = { version = "1.0.0", path = "../../../eppo_core" }
+eppo_core = { version = "1.0.0" }
 log = { version = "0.4.21", features = ["kv_serde"] }
 magnus = { version = "0.6.2" }
 serde = { version = "1.0.203", features = ["derive"] }


### PR DESCRIPTION
**Observation**

While performing validation of the ruby / rust gem I noticed a failure to install the gem in the test server.

🎫 https://linear.app/eppo/issue/FF-2758/ruby-gem-fails-to-install

**Description**

Augments CICD to attempt to install the gem locally so we have a repeatable process to validate its function.