### PR TITLE
bug: [allow eppo_core and rust-sdk to be published] (FF-2838)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,7 @@ name: Publish Crate
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always
@@ -21,13 +22,21 @@ jobs:
       - run: make test-data
       - name: Install Rust toolchain
         run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
-      - name: Build Release
-        run: cargo build --release --verbose
-      - name: Test
-        run: cargo test --verbose
-      - name: Docs
-        run: cargo doc --verbose
-      - name: Publish
-        run: cargo publish
+      - name: Build, Test, and Publish eppo_core
+        run: |
+          cd eppo_core
+          cargo build --release --verbose
+          cargo test --verbose
+          cargo doc --verbose
+          cargo publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+      - name: Build, Test, and Publish rust-sdk
+        run: |
+          cd rust-sdk
+          cargo build --release --verbose
+          cargo test --verbose
+          cargo doc --verbose
+          cargo publish
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,21 +22,17 @@ jobs:
       - run: make test-data
       - name: Install Rust toolchain
         run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
-      - name: Build, Test, and Publish eppo_core
-        run: |
-          cd eppo_core
-          cargo build --release --verbose
-          cargo test --verbose
-          cargo doc --verbose
-          cargo publish
+      - name: Build Release
+        run: cargo build --release --verbose
+      - name: Test
+        run: cargo test --verbose
+      - name: Docs
+        run: cargo doc --verbose
+      - name: Publish eppo_core
+        run: cargo publish -p eppo_core
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
-      - name: Build, Test, and Publish rust-sdk
-        run: |
-          cd rust-sdk
-          cargo build --release --verbose
-          cargo test --verbose
-          cargo doc --verbose
-          cargo publish
+      - name: Publish rust-sdk
+        run: cargo publish -p eppo
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}


### PR DESCRIPTION
🎫 https://linear.app/eppo/issue/FF-2838/fix-cargo-publish-script-to-account-for-eppo-core-and-rust-sdk

Log: https://github.com/Eppo-exp/rust-sdk/actions/runs/10050746627/job/27779182822

**Description**

* Modify the publish script to allow `eppo_core` and `rust-sdk` packages to be published to crate.io
* Allow github action to be run ad-hoc