### PR TITLE
bug: [fix path to `eppo_rb`] (FF-2853)

### DIFF
--- a/ruby-sdk/lib/eppo_client/client.rb
+++ b/ruby-sdk/lib/eppo_client/client.rb
@@ -4,7 +4,7 @@ require "singleton"
 require "logger"
 
 require_relative "config"
-require_relative "eppo_rb"
+require_relative "../eppo_rb/eppo_rb" # this gets copied into an unexpected location
 
 module EppoClient
   # The main client singleton


### PR DESCRIPTION
🎫 https://linear.app/eppo/issue/FF-2853/ruby-v3-client-has-invalid-path

**Description**

Fixed path to `eppo_rb` package.

During gem building it gets copied and doesn't line up with the directory structure in code:

```
cd -
cp lib/eppo_client/client.rb tmp/arm64-darwin23/stage/lib/eppo_client/client.rb
/usr/bin/make install sitearchdir=../../../../lib/eppo_client sitelibdir=../../../../lib/eppo_client target_prefix=
generating /Users/leo/src/rust-sdk/ruby-sdk/target/release/libeppo_rb.dylib (release)
cargo rustc  --manifest-path /Users/leo/src/rust-sdk/ruby-sdk/ext/eppo_rb/Cargo.toml --target-dir /Users/leo/src/rust-sdk/ruby-sdk/target --lib --profile release -- -C linker=clang -L native=/Users/leo/.rbenv/versions/3.3.2/lib -L native=/opt/homebrew/opt/gmp/lib -C link-arg=-Wl,-undefined,dynamic_lookup -l pthread
    Finished `release` profile [optimized] target(s) in 0.08s
installing eppo_rb.bundle to ../../../../lib/eppo_client
/usr/bin/install -c -m 0755 eppo_rb.bundle ../../../../lib/eppo_client
cp tmp/arm64-darwin23/eppo_rb/3.3.2/eppo_rb.bundle tmp/arm64-darwin23/stage/lib/eppo_client/eppo_rb.bundle
eppo-server-sdk 3.0.0 built to pkg/eppo-server-sdk-3.0.0.gem.
  Successfully built RubyGem
  Name: eppo-server-sdk
  Version: 3.0.0
  File: eppo-server-sdk-3.0.0.gem
```

**Testing**

```
➜  ruby-server-example git:(lr/ruby-v3) ✗ ruby example.rb XYZ ufc-log-allocation-options 123
API_KEY: XYZ
FLAG_KEY: ufc-log-allocation-options
SUBJECT_KEY: 123
starting eppo client
[2024-07-24T00:56:05Z DEBUG eppo] fetching new configuration
[2024-07-24T00:56:05Z DEBUG eppo] fetching UFC configuration
[2024-07-24T00:56:05Z DEBUG eppo] successfully fetched UFC configuration
[2024-07-24T00:56:05Z DEBUG eppo] fetching UFC configuration
[2024-07-24T00:56:06Z DEBUG eppo] successfully fetched UFC configuration
done starting eppo client
[2024-07-24T00:56:08Z TRACE eppo] evaluated a flag flag_key=ufc-log-allocation-options subject_key=123 subject_attributes={} assignment=Some(STRING("all"))
{:featureFlag=>"ufc-log-allocation-options", :allocation=>"allocation-3883", :experiment=>"ufc-log-allocation-options-allocation-3883", :variation=>"all", :subject=>"123", :subjectAttributes=>{}, :timestamp=>"2024-07-24T00:56:08.649677+00:00", :metaData=>{"eppoCoreVersion"=>"1.0.0", "sdkName"=>"ruby", "sdkVersion"=>"3.0.0"}}
VARIATION: all
```

**Question for reviewers** 

* Is there a better way to fix with - such as modifying the gem build?
* Can this be caught during CI?
* The `get_string_assignment` being undefined is known and being addressed separately