### PR TITLE
FF-2857 chore: add publish to rubygems

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,3 +36,29 @@ jobs:
         run: cargo publish -p eppo
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
+
+  publish_ruby:
+    name: Publish to RubyGems
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.0'
+      - name: Install dependencies
+        run: bundle install
+        working-directory: ruby-sdk
+      - name: Build
+        run: bundle exec rake build
+        working-directory: ruby-sdk
+      - name: Publish to RubyGems
+        run: |
+          mkdir -p $HOME/.gem
+          touch $HOME/.gem/credentials
+          chmod 0600 $HOME/.gem/credentials
+          printf -- "---\n:rubygems_api_key: ${RUBYGEMS_API_KEY}\n" > $HOME/.gem/credentials
+          gem push *.gem
+        env:
+          RUBYGEMS_API_KEY: "${{ secrets.RUBYGEMS_API_KEY }}"
+  

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,10 +12,7 @@ jobs:
   publish:
     name: Publish to Crates.io
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        toolchain:
-          - stable
+    if: ${{ startsWith(github.ref_name, 'eppo_core@') || startsWith(github.ref_name, 'rust-sdk@') }}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -24,37 +21,28 @@ jobs:
       - run: npm ci
       - run: make test-data
       - name: Install Rust toolchain
-        run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
+        run: rustup update stable && rustup default stable
       - name: Build Release
         run: cargo build --release --verbose
       - name: Test
         run: cargo test --verbose
       - name: Docs
         run: cargo doc --verbose
-      - name: Publish eppo_core library
-        run: |
-          VERSION=$(cargo pkgid | sed 's/.*#//')
-          if ! cargo search eppo_core | grep -q "^eppo_core = \"${VERSION}\""; then
-            cargo publish -p eppo_core
-          else
-            echo "eppo_core version ${VERSION} is already published, skipping."
-          fi
+      - name: Publish eppo_core
+        if: ${{ startsWith(github.ref_name, 'eppo_core@') }}
+        run: cargo publish -p eppo_core
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
-      - name: Publish Rust SDK
-        run: |
-          VERSION=$(cargo pkgid -p eppo | sed 's/.*#//')
-          if ! cargo search eppo | grep -q "^eppo = \"${VERSION}\""; then
-            cargo publish -p eppo
-          else
-            echo "eppo version ${VERSION} is already published, skipping."
-          fi
+      - name: Publish rust-sdk
+        if: ${{ startsWith(github.ref_name, 'rust-sdk@') }}
+        run: cargo publish -p eppo
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
 
   publish_ruby:
     name: Publish to RubyGems
     runs-on: ubuntu-latest
+    if: ${{ startsWith(github.ref_name, 'ruby-sdk@') }}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,6 +18,9 @@ jobs:
           - stable
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '20'
       - run: npm ci
       - run: make test-data
       - name: Install Rust toolchain
@@ -28,12 +31,24 @@ jobs:
         run: cargo test --verbose
       - name: Docs
         run: cargo doc --verbose
-      - name: Publish eppo_core
-        run: cargo publish -p eppo_core
+      - name: Publish eppo_core library
+        run: |
+          VERSION=$(cargo pkgid | sed 's/.*#//')
+          if ! cargo search eppo_core | grep -q "^eppo_core = \"${VERSION}\""; then
+            cargo publish -p eppo_core
+          else
+            echo "eppo_core version ${VERSION} is already published, skipping."
+          fi
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
-      - name: Publish rust-sdk
-        run: cargo publish -p eppo
+      - name: Publish Rust SDK
+        run: |
+          VERSION=$(cargo pkgid -p eppo | sed 's/.*#//')
+          if ! cargo search eppo | grep -q "^eppo = \"${VERSION}\""; then
+            cargo publish -p eppo
+          else
+            echo "eppo version ${VERSION} is already published, skipping."
+          fi
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
 
@@ -64,4 +79,3 @@ jobs:
           gem push *.gem
         env:
           RUBYGEMS_API_KEY: "${{ secrets.RUBYGEMS_API_KEY }}"
-  

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,6 +42,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '20'
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,19 @@
-name: Publish Crate
+# This workflow publishes releases to upstream registries (crates.io
+# for Rust crates, rubygems.org for Ruby gems).
+#
+# The release process is somewhat convoluted due to interdependencies
+# between packages (most notably, Ruby gem requires eppo_core to be
+# published beforehand and ruby-sdk/Cargo.lock to be updated with the
+# proper hash), so we cannot release all packages in one go.
+#
+# To workaround these complications, the release process is staged and
+# packages are released based on the release tag name.
+#
+# The following names are supported:
+# - eppo_core@*.*.* to publish eppo_core to crates.io.
+# - rust-sdk@*.*.* to publish Rust SDK.
+# - ruby-sdk@*.*.* to publish Ruby SDK.
+name: Publish Release
 
 on:
   release:


### PR DESCRIPTION
* Adds ability to publish to ruby gems
* Continues with publish if a dependent version already exists
* Added `RUBYGEMS_API_KEY` environment variable to github repo with permission to publish to https://rubygems.org/gems/eppo-server-sdk

**Testing**

Ran the steps manually: https://rubygems.org/gems/eppo-server-sdk