### PR TITLE
chore: add sdk-test-data as a submodule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,10 @@ jobs:
         toolchain:
           - stable
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
       - run: npm ci
-      - run: make test-data
       - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
       - run: cargo build --verbose
       - run: cargo test --verbose
@@ -37,6 +38,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: true
 
       - name: Set up Ruby & Rust
         uses: oxidize-rb/actions/setup-ruby-and-rust@v1
@@ -47,7 +50,6 @@ jobs:
           rubygems: '3.5.11'
 
       - run: npm ci
-      - run: make test-data
 
       - name: Check Cargo.lock
         # Ensure that Cargo.lock matches Cargo.toml

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -19,7 +19,9 @@ jobs:
           - stable
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
       - uses: actions/cache@v2
         with:
           path: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,12 +29,13 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ startsWith(github.ref_name, 'eppo_core@') || startsWith(github.ref_name, 'rust-sdk@') }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
       - uses: actions/setup-node@v3
         with:
           node-version: '20'
       - run: npm ci
-      - run: make test-data
       - name: Install Rust toolchain
         run: rustup update stable && rustup default stable
       - name: Build Release
@@ -59,7 +60,9 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ startsWith(github.ref_name, 'ruby-sdk@') }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
       - uses: actions/setup-node@v3
         with:
           node-version: '20'

--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,4 @@
 # MSVC Windows builds of rustc generate these, which store debugging information
 *.pdb
 
-/sdk-test-data/
 node_modules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "sdk-test-data"]
+	path = sdk-test-data
+	url = https://github.com/Eppo-exp/sdk-test-data.git

--- a/Makefile
+++ b/Makefile
@@ -23,19 +23,6 @@ help: Makefile
 	@echo "usage: make <target>"
 	@sed -n 's/^##//p' $<
 
-## test-data
-testDataDir := sdk-test-data
-branchName := main
-githubRepoLink := https://github.com/Eppo-exp/sdk-test-data.git
-.PHONY: test-data
-test-data:
-	rm -rf ${testDataDir}
-	git clone -b ${branchName} --depth 1 --single-branch ${githubRepoLink} ${testDataDir}
-
-${testDataDir}:
-	rm -rf ${testDataDir}
-	git clone -b ${branchName} --depth 1 --single-branch ${githubRepoLink} ${testDataDir}
-
 .PHONY: test
 test: ${testDataDir}
 	npm test


### PR DESCRIPTION
I'm somewhat tired of `sdk-test-data` updates breaking this SDK unprompted. I also want the ability to apply test-data fixes in branches (e.g., #13 is currently blocked by https://github.com/Eppo-exp/sdk-test-data/pull/49).

Plan:
- add `sdk-test-data` as a submodule so that we can update it when we're ready (instead of updates being pushed on us unexpectedly). (this PR)
- make [Eppo-exp/sdk-test-data](https://github.com/Eppo-exp/sdk-test-data) open a pull request against [Eppo-exp/rust-sdk](https://github.com/Eppo-exp/rust-sdk) when test data change. This will allow our CI validate tests and gives us a chance to adapt our code to new tests before we accept the PR. (Will open a PR on sdk-test-data after this one is merged.)