### PR TITLE
chore(ruby): fix ruby publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.0'
+          ruby-version: '3.3'
       - name: Check Cargo.lock
         # Ensure that Cargo.lock matches Cargo.toml
         run: cargo update --workspace --locked --verbose

--- a/ruby-sdk/eppo-server-sdk.gemspec
+++ b/ruby-sdk/eppo-server-sdk.gemspec
@@ -12,6 +12,8 @@ Gem::Specification.new do |spec|
   spec.homepage = "https://github.com/Eppo-exp/ruby-sdk"
   spec.license = "MIT"
   spec.required_ruby_version = ">= 3.0.0"
+  # RubyGems 3.3.11 is the first version with Rust support:
+  # https://blog.rubygems.org/2022/04/07/3.3.11-released.html
   spec.required_rubygems_version = ">= 3.3.11"
 
   spec.metadata = {


### PR DESCRIPTION
Our publish workflow uses Ruby 3.0 to push the gem. Ruby 3.0 ships with RubyGems 3.2.3 which is below our minimum required version (3.3.11).

The version used for publishing does not affect the result of publishing. It's just using the old/unmaintained version of Ruby to do the build and push itself (which also has security concerns).

Update Ruby in publish workflow to 3.3.