### PR TITLE
chore(ruby): specify proper location for gem file in publish flow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -86,6 +86,7 @@ jobs:
           touch $HOME/.gem/credentials
           chmod 0600 $HOME/.gem/credentials
           printf -- "---\n:rubygems_api_key: ${RUBYGEMS_API_KEY}\n" > $HOME/.gem/credentials
-          gem push *.gem
+          gem push pkg/eppo-server-sdk-*.gem
         env:
           RUBYGEMS_API_KEY: "${{ secrets.RUBYGEMS_API_KEY }}"
+        working-directory: ruby-sdk

--- a/ruby-sdk/Gemfile.lock
+++ b/ruby-sdk/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    eppo-server-sdk (3.0.0)
+    eppo-server-sdk (3.1.0)
 
 GEM
   remote: https://rubygems.org/


### PR DESCRIPTION
Workflow step was running in the wrong directory and tried to push a non-existent file