### PR TITLE
FF-3204 perf: compile regex during parsing

### DIFF
--- a/eppo_core/benches/evaluation_details.rs
+++ b/eppo_core/benches/evaluation_details.rs
@@ -128,6 +128,35 @@ fn criterion_benchmark(c: &mut Criterion) {
         });
         group.finish();
     }
+
+    {
+        let mut group = c.benchmark_group("regex-flag");
+        group.throughput(Throughput::Elements(1));
+        let attributes = [("email".into(), "test@gmail.com".into())].into();
+        group.bench_function("get_assignment", |b| {
+            b.iter(|| {
+                get_assignment(
+                    black_box(Some(&configuration)),
+                    black_box("regex-flag"),
+                    black_box("subject1"),
+                    black_box(&attributes),
+                    black_box(None),
+                )
+            })
+        });
+        group.bench_function("get_assignment_details", |b| {
+            b.iter(|| {
+                get_assignment_details(
+                    black_box(Some(&configuration)),
+                    black_box("regex-flag"),
+                    black_box("subject1"),
+                    black_box(&attributes),
+                    black_box(None),
+                )
+            })
+        });
+        group.finish();
+    }
 }
 
 criterion_group!(

--- a/eppo_core/src/attributes.rs
+++ b/eppo_core/src/attributes.rs
@@ -41,6 +41,17 @@ pub enum AttributeValue {
     /// A null value or absence of value.
     Null,
 }
+
+impl AttributeValue {
+    pub fn as_str(&self) -> Option<&str> {
+        if let AttributeValue::String(s) = self {
+            Some(s.as_str())
+        } else {
+            None
+        }
+    }
+}
+
 impl From<&str> for AttributeValue {
     fn from(value: &str) -> Self {
         Self::String(value.to_owned())

--- a/eppo_core/src/eval/eval_details.rs
+++ b/eppo_core/src/eval/eval_details.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     error::{EvaluationError, EvaluationFailure},
-    ufc::{Condition, Shard, Value},
+    ufc::{ConditionWire, Shard, Value},
     AttributeValue, Attributes,
 };
 
@@ -135,7 +135,7 @@ pub struct RuleEvaluationDetails {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ConditionEvaluationDetails {
-    pub condition: Condition,
+    pub condition: ConditionWire,
     pub attribute_value: Option<AttributeValue>,
     pub matched: bool,
 }

--- a/eppo_core/src/eval/eval_rules.rs
+++ b/eppo_core/src/eval/eval_rules.rs
@@ -1,8 +1,9 @@
-use regex::Regex;
+use std::borrow::Cow;
+
 use semver::Version;
 
 use crate::{
-    ufc::{Condition, ConditionOperator, ConditionValue, Rule, Value},
+    ufc::{Comparand, ComparisonOperator, Condition, ConditionCheck, Rule, TryParse},
     AttributeValue, Attributes,
 };
 
@@ -14,128 +15,97 @@ impl Rule {
         visitor: &mut V,
         attributes: &Attributes,
     ) -> bool {
-        self.conditions
-            .iter()
-            .all(|condition| condition.eval(visitor, attributes))
+        self.conditions.iter().all(|condition| match condition {
+            TryParse::Parsed(condition) => condition.eval(visitor, attributes),
+            TryParse::ParseFailed(raw_condition) => {
+                visitor.on_condition_skip(raw_condition);
+                false
+            }
+        })
     }
 }
 
 impl Condition {
     fn eval<V: EvalRuleVisitor>(&self, visitor: &mut V, attributes: &Attributes) -> bool {
-        let attribute = attributes.get(&self.attribute);
-        let result = self.operator.eval(attribute, &self.value);
+        let attribute = attributes.get(self.attribute.as_ref());
+        let result = self.check.eval(attribute);
         visitor.on_condition_eval(self, attribute, result);
         result
     }
 }
 
-impl ConditionOperator {
-    /// Applying `Operator` to the values. Returns `false` if the operator cannot be applied or
-    /// there's a misconfiguration.
-    fn eval(&self, attribute: Option<&AttributeValue>, condition_value: &ConditionValue) -> bool {
-        self.try_eval(attribute, condition_value).unwrap_or(false)
+impl ConditionCheck {
+    /// Check if `attribute` matches.
+    fn eval(&self, attribute: Option<&AttributeValue>) -> bool {
+        self.try_eval(attribute).unwrap_or(false)
     }
 
     /// Try applying `Operator` to the values, returning `None` if the operator cannot be applied.
-    fn try_eval(
-        &self,
-        attribute: Option<&AttributeValue>,
-        condition_value: &ConditionValue,
-    ) -> Option<bool> {
-        match self {
-            Self::Matches | Self::NotMatches => {
-                let s = match attribute {
-                    Some(AttributeValue::String(s)) => s.clone(),
-                    Some(AttributeValue::Boolean(b)) => b.to_string(),
-                    _ => return None,
+    fn try_eval(&self, attribute: Option<&AttributeValue>) -> Option<bool> {
+        let result = match self {
+            ConditionCheck::Comparison {
+                operator,
+                comparand,
+            } => {
+                let attribute = attribute?;
+                let ordering = match comparand {
+                    Comparand::Version(comparand) => {
+                        let attribute = Version::parse(attribute.as_str()?).ok()?;
+                        attribute.cmp(comparand)
+                    }
+                    Comparand::Number(comparand) => {
+                        let attribute = match attribute {
+                            AttributeValue::Number(n) => *n,
+                            AttributeValue::String(s) => s.parse().ok()?,
+                            _ => return None,
+                        };
+                        attribute.partial_cmp(comparand)?
+                    }
                 };
-                let regex = match condition_value {
-                    ConditionValue::Single(Value::String(s)) => Regex::new(s).ok()?,
-                    _ => return None,
-                };
-                let matches = regex.is_match(&s);
-                Some(if matches!(self, Self::Matches) {
-                    matches
-                } else {
-                    !matches
-                })
-            }
-
-            Self::OneOf | Self::NotOneOf => {
-                let s = match attribute {
-                    Some(AttributeValue::String(s)) => s.clone(),
-                    Some(AttributeValue::Number(n)) => n.to_string(),
-                    Some(AttributeValue::Boolean(b)) => b.to_string(),
-                    _ => return None,
-                };
-                let values = match condition_value {
-                    ConditionValue::Multiple(v) => v,
-                    _ => return None,
-                };
-                let is_one_of = values.iter().any(|v| v == &s);
-                let has_to_be_one_of = *self == Self::OneOf;
-                Some(is_one_of == has_to_be_one_of)
-            }
-
-            Self::IsNull => {
-                let is_null = attribute.is_none() || attribute == Some(&AttributeValue::Null);
-                let ConditionValue::Single(Value::Boolean(expected_null)) = condition_value else {
-                    return None;
-                };
-                Some(is_null == *expected_null)
-            }
-
-            Self::Gte | Self::Gt | Self::Lte | Self::Lt => {
-                let condition_version = match condition_value {
-                    ConditionValue::Single(Value::String(s)) => Version::parse(s).ok(),
-                    _ => None,
-                };
-
-                if let Some(condition_version) = condition_version {
-                    // semver comparison
-
-                    let attribute_version = match attribute {
-                        Some(AttributeValue::String(s)) => Version::parse(s).ok(),
-                        _ => None,
-                    }?;
-
-                    Some(match self {
-                        Self::Gt => attribute_version > condition_version,
-                        Self::Gte => attribute_version >= condition_version,
-                        Self::Lt => attribute_version < condition_version,
-                        Self::Lte => attribute_version <= condition_version,
-                        _ => {
-                            // unreachable
-                            return None;
-                        }
-                    })
-                } else {
-                    // numeric comparison
-                    let condition_value = match condition_value {
-                        ConditionValue::Single(Value::Number(n)) => *n,
-                        ConditionValue::Single(Value::String(s)) => s.parse().ok()?,
-                        _ => return None,
-                    };
-
-                    let attribute_value = match attribute {
-                        Some(AttributeValue::Number(n)) => *n,
-                        Some(AttributeValue::String(s)) => s.parse().ok()?,
-                        _ => return None,
-                    };
-
-                    Some(match self {
-                        Self::Gt => attribute_value > condition_value,
-                        Self::Gte => attribute_value >= condition_value,
-                        Self::Lt => attribute_value < condition_value,
-                        Self::Lte => attribute_value <= condition_value,
-                        _ => {
-                            // unreachable
-                            return None;
-                        }
-                    })
+                match operator {
+                    ComparisonOperator::Gte => ordering.is_gt() || ordering.is_eq(),
+                    ComparisonOperator::Gt => ordering.is_gt(),
+                    ComparisonOperator::Lte => ordering.is_lt() || ordering.is_eq(),
+                    ComparisonOperator::Lt => ordering.is_lt(),
                 }
             }
-        }
+            ConditionCheck::Regex {
+                expected_match,
+                regex,
+            } => {
+                let s = match attribute? {
+                    AttributeValue::String(s) => s.as_str(),
+                    AttributeValue::Boolean(v) => {
+                        if *v {
+                            "true"
+                        } else {
+                            "false"
+                        }
+                    }
+                    _ => return None,
+                };
+                regex.is_match(s) == *expected_match
+            }
+            ConditionCheck::Membership {
+                expected_membership,
+                values,
+            } => {
+                let s = match attribute? {
+                    AttributeValue::String(s) => Cow::Borrowed(s.as_str()),
+                    AttributeValue::Number(n) => Cow::Owned(n.to_string()),
+                    AttributeValue::Boolean(b) => Cow::Borrowed(if *b { "true" } else { "false" }),
+                    _ => return None,
+                };
+                let s = s.as_ref();
+                values.into_iter().any(|it| it.as_ref() == s) == *expected_membership
+            }
+            ConditionCheck::Null { expected_null } => {
+                let is_null = attribute.is_none() || attribute == Some(&AttributeValue::Null);
+                is_null == *expected_null
+            }
+        };
+
+        Some(result)
     }
 }
 
@@ -145,154 +115,255 @@ mod tests {
 
     use crate::{
         eval::eval_visitor::NoopEvalVisitor,
-        ufc::{Condition, ConditionOperator, Rule},
+        ufc::{Comparand, ComparisonOperator, Condition, ConditionCheck, Rule},
     };
 
     #[test]
     fn matches_regex() {
-        assert!(
-            ConditionOperator::Matches.eval(Some(&"test@example.com".into()), &"^test.*".into())
-        );
-        assert!(
-            !ConditionOperator::Matches.eval(Some(&"example@test.com".into()), &"^test.*".into())
-        );
+        let check = ConditionCheck::Regex {
+            expected_match: true,
+            regex: "^test.*".try_into().unwrap(),
+        };
+        assert!(check.eval(Some(&"test@example.com".into())));
+        assert!(!check.eval(Some(&"example@test.com".into())));
+        assert!(!check.eval(None));
     }
 
     #[test]
     fn not_matches_regex() {
-        assert!(!ConditionOperator::NotMatches
-            .eval(Some(&"test@example.com".into()), &"^test.*".into()));
-        assert!(!ConditionOperator::NotMatches.eval(None, &"^test.*".into()));
-        assert!(
-            ConditionOperator::NotMatches.eval(Some(&"example@test.com".into()), &"^test.*".into())
-        );
+        let check = ConditionCheck::Regex {
+            expected_match: false,
+            regex: "^test.*".try_into().unwrap(),
+        };
+        assert!(!check.eval(Some(&"test@example.com".into())));
+        assert!(check.eval(Some(&"example@test.com".into())));
+        assert!(!check.eval(None));
     }
 
     #[test]
     fn one_of() {
-        assert!(ConditionOperator::OneOf.eval(
-            Some(&"alice".into()),
-            &vec![String::from("alice"), String::from("bob")].into()
-        ));
-        assert!(ConditionOperator::OneOf.eval(
-            Some(&"bob".into()),
-            &vec![String::from("alice"), String::from("bob")].into()
-        ));
-        assert!(!ConditionOperator::OneOf.eval(
-            Some(&"charlie".into()),
-            &vec![String::from("alice"), String::from("bob")].into()
-        ));
+        let check = ConditionCheck::Membership {
+            expected_membership: true,
+            values: ["alice".into(), "bob".into()].into(),
+        };
+        assert!(check.eval(Some(&"alice".into())));
+        assert!(check.eval(Some(&"bob".into())));
+        assert!(!check.eval(Some(&"charlie".into())));
     }
 
     #[test]
     fn not_one_of() {
-        assert!(!ConditionOperator::NotOneOf.eval(
-            Some(&"alice".into()),
-            &vec![String::from("alice"), String::from("bob")].into()
-        ));
-        assert!(!ConditionOperator::NotOneOf.eval(
-            Some(&"bob".into()),
-            &vec![String::from("alice"), String::from("bob")].into()
-        ));
-        assert!(ConditionOperator::NotOneOf.eval(
-            Some(&"charlie".into()),
-            &vec![String::from("alice"), String::from("bob")].into()
-        ));
+        let check = ConditionCheck::Membership {
+            expected_membership: false,
+            values: ["alice".into(), "bob".into()].into(),
+        };
+        assert!(!check.eval(Some(&"alice".into())));
+        assert!(!check.eval(Some(&"bob".into())));
+        assert!(check.eval(Some(&"charlie".into())));
 
         // NOT_ONE_OF fails when attribute is not specified
-        assert!(!ConditionOperator::NotOneOf.eval(
-            None,
-            &vec![String::from("alice"), String::from("bob")].into()
-        ));
+        assert!(!check.eval(None));
     }
 
     #[test]
     fn one_of_int() {
-        assert!(ConditionOperator::OneOf.eval(Some(&42.0.into()), &vec![String::from("42")].into()));
+        assert!(ConditionCheck::Membership {
+            expected_membership: true,
+            values: ["42".into()].into()
+        }
+        .eval(Some(&42.0.into())));
     }
 
     #[test]
     fn one_of_bool() {
-        assert!(
-            ConditionOperator::OneOf.eval(Some(&true.into()), &vec![String::from("true")].into())
-        );
-        assert!(
-            ConditionOperator::OneOf.eval(Some(&false.into()), &vec![String::from("false")].into())
-        );
-        assert!(
-            !ConditionOperator::OneOf.eval(Some(&1.0.into()), &vec![String::from("true")].into())
-        );
-        assert!(
-            !ConditionOperator::OneOf.eval(Some(&0.0.into()), &vec![String::from("false")].into())
-        );
-        assert!(!ConditionOperator::OneOf.eval(None, &vec![String::from("true")].into()));
-        assert!(!ConditionOperator::OneOf.eval(None, &vec![String::from("false")].into()));
+        let true_check = ConditionCheck::Membership {
+            expected_membership: true,
+            values: ["true".into()].into(),
+        };
+        let false_check = ConditionCheck::Membership {
+            expected_membership: true,
+            values: ["false".into()].into(),
+        };
+        assert!(true_check.eval(Some(&true.into())));
+        assert!(false_check.eval(Some(&false.into())));
+        assert!(!true_check.eval(Some(&1.0.into())));
+        assert!(!false_check.eval(Some(&0.0.into())));
+        assert!(!true_check.eval(None));
+        assert!(!false_check.eval(None));
     }
 
     #[test]
     fn is_null() {
-        assert!(ConditionOperator::IsNull.eval(None, &true.into()));
-        assert!(!ConditionOperator::IsNull.eval(Some(&10.0.into()), &true.into()));
+        assert!(ConditionCheck::Null {
+            expected_null: true
+        }
+        .eval(None));
+        assert!(!ConditionCheck::Null {
+            expected_null: true
+        }
+        .eval(Some(&10.0.into())));
     }
 
     #[test]
     fn is_not_null() {
-        assert!(!ConditionOperator::IsNull.eval(None, &false.into()));
-        assert!(ConditionOperator::IsNull.eval(Some(&10.0.into()), &false.into()));
+        assert!(!ConditionCheck::Null {
+            expected_null: false
+        }
+        .eval(None));
+        assert!(ConditionCheck::Null {
+            expected_null: false
+        }
+        .eval(Some(&10.0.into())));
     }
 
     #[test]
     fn gte() {
-        assert!(ConditionOperator::Gte.eval(Some(&18.0.into()), &18.0.into()));
-        assert!(!ConditionOperator::Gte.eval(Some(&17.0.into()), &18.0.into()));
+        let check = ConditionCheck::Comparison {
+            operator: ComparisonOperator::Gte,
+            comparand: Comparand::Number(18.0),
+        };
+        assert!(check.eval(Some(&18.0.into())));
+        assert!(!check.eval(Some(&17.0.into())));
     }
     #[test]
     fn gt() {
-        assert!(ConditionOperator::Gt.eval(Some(&19.0.into()), &18.0.into()));
-        assert!(!ConditionOperator::Gt.eval(Some(&18.0.into()), &18.0.into()));
+        let check = ConditionCheck::Comparison {
+            operator: ComparisonOperator::Gt,
+            comparand: Comparand::Number(18.0),
+        };
+        assert!(check.eval(Some(&19.0.into())));
+        assert!(!check.eval(Some(&18.0.into())));
     }
     #[test]
     fn lte() {
-        assert!(ConditionOperator::Lte.eval(Some(&18.0.into()), &18.0.into()));
-        assert!(!ConditionOperator::Lte.eval(Some(&19.0.into()), &18.0.into()));
+        let check = ConditionCheck::Comparison {
+            operator: ComparisonOperator::Lte,
+            comparand: Comparand::Number(18.0),
+        };
+        assert!(check.eval(Some(&18.0.into())));
+        assert!(!check.eval(Some(&19.0.into())));
     }
     #[test]
     fn lt() {
-        assert!(ConditionOperator::Lt.eval(Some(&17.0.into()), &18.0.into()));
-        assert!(!ConditionOperator::Lt.eval(Some(&18.0.into()), &18.0.into()));
+        let check = ConditionCheck::Comparison {
+            operator: ComparisonOperator::Lt,
+            comparand: Comparand::Number(18.0),
+        };
+        assert!(check.eval(Some(&17.0.into())));
+        assert!(!check.eval(Some(&18.0.into())));
     }
 
     #[test]
     fn semver_gte() {
-        assert!(ConditionOperator::Gte.eval(Some(&"1.0.1".into()), &"1.0.0".into()));
-        assert!(ConditionOperator::Gte.eval(Some(&"1.0.0".into()), &"1.0.0".into()));
-        assert!(!ConditionOperator::Gte.eval(Some(&"1.2.0".into()), &"1.10.0".into()));
-        assert!(ConditionOperator::Gte.eval(Some(&"1.13.0".into()), &"1.5.0".into()));
-        assert!(!ConditionOperator::Gte.eval(Some(&"0.9.9".into()), &"1.0.0".into()));
+        assert!(ConditionCheck::Comparison {
+            operator: ComparisonOperator::Gte,
+            comparand: Comparand::Version("1.0.0".parse().unwrap())
+        }
+        .eval(Some(&"1.0.1".into())));
+        assert!(ConditionCheck::Comparison {
+            operator: ComparisonOperator::Gte,
+            comparand: Comparand::Version("1.0.0".parse().unwrap())
+        }
+        .eval(Some(&"1.0.0".into())));
+        assert!(!ConditionCheck::Comparison {
+            operator: ComparisonOperator::Gte,
+            comparand: Comparand::Version("1.10.0".parse().unwrap())
+        }
+        .eval(Some(&"1.2.0".into())));
+        assert!(ConditionCheck::Comparison {
+            operator: ComparisonOperator::Gte,
+            comparand: Comparand::Version("1.5.0".parse().unwrap())
+        }
+        .eval(Some(&"1.13.0".into())));
+        assert!(!ConditionCheck::Comparison {
+            operator: ComparisonOperator::Gte,
+            comparand: Comparand::Version("1.0.0".parse().unwrap())
+        }
+        .eval(Some(&"0.9.9".into())));
     }
     #[test]
     fn semver_gt() {
-        assert!(ConditionOperator::Gt.eval(Some(&"1.0.1".into()), &"1.0.0".into()));
-        assert!(!ConditionOperator::Gt.eval(Some(&"1.0.0".into()), &"1.0.0".into()));
-        assert!(!ConditionOperator::Gt.eval(Some(&"1.2.0".into()), &"1.10.0".into()));
-        assert!(ConditionOperator::Gt.eval(Some(&"1.13.0".into()), &"1.5.0".into()));
-        assert!(!ConditionOperator::Gt.eval(Some(&"0.9.9".into()), &"1.0.0".into()));
+        assert!(ConditionCheck::Comparison {
+            operator: ComparisonOperator::Gt,
+            comparand: Comparand::Version("1.0.0".parse().unwrap())
+        }
+        .eval(Some(&"1.0.1".into())));
+        assert!(!ConditionCheck::Comparison {
+            operator: ComparisonOperator::Gt,
+            comparand: Comparand::Version("1.0.0".parse().unwrap())
+        }
+        .eval(Some(&"1.0.0".into())));
+        assert!(!ConditionCheck::Comparison {
+            operator: ComparisonOperator::Gt,
+            comparand: Comparand::Version("1.10.0".parse().unwrap())
+        }
+        .eval(Some(&"1.2.0".into())));
+        assert!(ConditionCheck::Comparison {
+            operator: ComparisonOperator::Gt,
+            comparand: Comparand::Version("1.5.0".parse().unwrap())
+        }
+        .eval(Some(&"1.13.0".into())));
+        assert!(!ConditionCheck::Comparison {
+            operator: ComparisonOperator::Gt,
+            comparand: Comparand::Version("1.0.0".parse().unwrap())
+        }
+        .eval(Some(&"0.9.9".into())));
     }
     #[test]
     fn semver_lte() {
-        assert!(!ConditionOperator::Lte.eval(Some(&"1.0.1".into()), &"1.0.0".into()));
-        assert!(ConditionOperator::Lte.eval(Some(&"1.0.0".into()), &"1.0.0".into()));
-        assert!(ConditionOperator::Lte.eval(Some(&"1.2.0".into()), &"1.10.0".into()));
-        assert!(!ConditionOperator::Lte.eval(Some(&"1.13.0".into()), &"1.5.0".into()));
-        assert!(ConditionOperator::Lte.eval(Some(&"0.9.9".into()), &"1.0.0".into()));
+        assert!(!ConditionCheck::Comparison {
+            operator: ComparisonOperator::Lte,
+            comparand: Comparand::Version("1.0.0".parse().unwrap())
+        }
+        .eval(Some(&"1.0.1".into())));
+        assert!(ConditionCheck::Comparison {
+            operator: ComparisonOperator::Lte,
+            comparand: Comparand::Version("1.0.0".parse().unwrap())
+        }
+        .eval(Some(&"1.0.0".into())));
+        assert!(ConditionCheck::Comparison {
+            operator: ComparisonOperator::Lte,
+            comparand: Comparand::Version("1.10.0".parse().unwrap())
+        }
+        .eval(Some(&"1.2.0".into())));
+        assert!(!ConditionCheck::Comparison {
+            operator: ComparisonOperator::Lte,
+            comparand: Comparand::Version("1.5.0".parse().unwrap())
+        }
+        .eval(Some(&"1.13.0".into())));
+        assert!(ConditionCheck::Comparison {
+            operator: ComparisonOperator::Lte,
+            comparand: Comparand::Version("1.0.0".parse().unwrap())
+        }
+        .eval(Some(&"0.9.9".into())));
     }
     #[test]
     fn semver_lt() {
-        assert!(!ConditionOperator::Lt.eval(Some(&"1.0.1".into()), &"1.0.0".into()));
-        assert!(!ConditionOperator::Lt.eval(Some(&"1.0.0".into()), &"1.0.0".into()));
-        assert!(ConditionOperator::Lt.eval(Some(&"1.2.0".into()), &"1.10.0".into()));
-        assert!(!ConditionOperator::Lt.eval(Some(&"1.13.0".into()), &"1.5.0".into()));
-        assert!(ConditionOperator::Lt.eval(Some(&"0.9.9".into()), &"1.0.0".into()));
+        assert!(!ConditionCheck::Comparison {
+            operator: ComparisonOperator::Lt,
+            comparand: Comparand::Version("1.0.0".parse().unwrap())
+        }
+        .eval(Some(&"1.0.1".into())));
+        assert!(!ConditionCheck::Comparison {
+            operator: ComparisonOperator::Lt,
+            comparand: Comparand::Version("1.0.0".parse().unwrap())
+        }
+        .eval(Some(&"1.0.0".into())));
+        assert!(ConditionCheck::Comparison {
+            operator: ComparisonOperator::Lt,
+            comparand: Comparand::Version("1.10.0".parse().unwrap())
+        }
+        .eval(Some(&"1.2.0".into())));
+        assert!(!ConditionCheck::Comparison {
+            operator: ComparisonOperator::Lt,
+            comparand: Comparand::Version("1.5.0".parse().unwrap())
+        }
+        .eval(Some(&"1.13.0".into())));
+        assert!(ConditionCheck::Comparison {
+            operator: ComparisonOperator::Lt,
+            comparand: Comparand::Version("1.0.0".parse().unwrap())
+        }
+        .eval(Some(&"0.9.9".into())));
     }
 
     #[test]
@@ -306,9 +377,12 @@ mod tests {
         let rule = Rule {
             conditions: vec![Condition {
                 attribute: "age".into(),
-                operator: ConditionOperator::Gt,
-                value: 10.0.into(),
-            }],
+                check: ConditionCheck::Comparison {
+                    operator: ComparisonOperator::Gt,
+                    comparand: 10.0.into(),
+                },
+            }
+            .into()],
         };
         assert!(rule.eval(
             &mut NoopEvalVisitor,
@@ -322,14 +396,20 @@ mod tests {
             conditions: vec![
                 Condition {
                     attribute: "age".into(),
-                    operator: ConditionOperator::Gt,
-                    value: 18.0.into(),
-                },
+                    check: ConditionCheck::Comparison {
+                        operator: ComparisonOperator::Gt,
+                        comparand: 18.0.into(),
+                    },
+                }
+                .into(),
                 Condition {
                     attribute: "age".into(),
-                    operator: ConditionOperator::Lt,
-                    value: 100.0.into(),
-                },
+                    check: ConditionCheck::Comparison {
+                        operator: ComparisonOperator::Lt,
+                        comparand: 100.0.into(),
+                    },
+                }
+                .into(),
             ],
         };
         assert!(rule.eval(
@@ -351,9 +431,12 @@ mod tests {
         let rule = Rule {
             conditions: vec![Condition {
                 attribute: "age".into(),
-                operator: ConditionOperator::Gt,
-                value: 10.0.into(),
-            }],
+                check: ConditionCheck::Comparison {
+                    operator: ComparisonOperator::Gt,
+                    comparand: 10.0.into(),
+                },
+            }
+            .into()],
         };
         assert!(!rule.eval(
             &mut NoopEvalVisitor,

--- a/eppo_core/src/eval/eval_visitor.rs
+++ b/eppo_core/src/eval/eval_visitor.rs
@@ -80,15 +80,18 @@ pub(super) trait EvalAllocationVisitor {
 }
 
 pub(super) trait EvalRuleVisitor {
-    #[allow(unused_variables)]
-    #[inline]
+    /// Called when condition is skipped due to being invalid (e.g., regex cannot be compiled or
+    /// server response is ill-formatted).
+    ///
+    /// `condition` is original server response.
+    fn on_condition_skip(&mut self, condition: &serde_json::Value);
+
     fn on_condition_eval(
         &mut self,
         condition: &Condition,
         attribute_value: Option<&AttributeValue>,
         result: bool,
-    ) {
-    }
+    );
 
     #[allow(unused_variables)]
     #[inline]
@@ -153,6 +156,18 @@ impl EvalAllocationVisitor for NoopEvalVisitor {
     }
 }
 
-impl EvalRuleVisitor for NoopEvalVisitor {}
+impl EvalRuleVisitor for NoopEvalVisitor {
+    #[inline]
+    fn on_condition_skip(&mut self, _condition: &serde_json::Value) {}
+
+    #[inline]
+    fn on_condition_eval(
+        &mut self,
+        _condition: &Condition,
+        _attribute_value: Option<&AttributeValue>,
+        _result: bool,
+    ) {
+    }
+}
 
 impl EvalSplitVisitor for NoopEvalVisitor {}


### PR DESCRIPTION
After benchmarking Rust core and Python SDK, I noticed that rust core performs quite badly on regex conditions. Immediate reaction: regex compilation is kinda slow and we do it on every evaluation call.

This PR moves regex compilation from evaluation phase to parsing, so it happens only once and in background (doesn't slow down evaluation calls).

## Description of changes
- This PR adds `ConditionWire` struct, which is the structure we receive from the server (what is transferred "on the wire").
- `Condition` is a new type and optimized for evaluation. There are function to convert back and forth between the two formats. In additional to parsing regex, we also prepare other conditions:
  - For comparison operator, we parse version string beforehand
  - Check that condition value matches the condition operator (e.g., `IS_NULL` expects a boolean condition value)
- Evaluation details is adjusted to store `ConditionWire`, so the change is not visible to users

## Results

Comparing against pre-optimization, regex evaluation is ~150x faster now (from ~45us down to 300ns):

```
regex-flag/get_assignment
                        time:   [295.74 ns 296.20 ns 296.71 ns]
                        thrpt:  [3.3703 Melem/s 3.3761 Melem/s 3.3813 Melem/s]
                 change:
                        time:   [-99.355% -99.354% -99.352%] (p = 0.00 < 0.05)
                        thrpt:  [+15338% +15369% +15403%]
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  7 (7.00%) high mild

regex-flag/get_assignment_details
                        time:   [1.8295 µs 1.8331 µs 1.8369 µs]
                        thrpt:  [544.40 Kelem/s 545.53 Kelem/s 546.60 Kelem/s]
                 change:
                        time:   [-96.137% -96.112% -96.093%] (p = 0.00 < 0.05)
                        thrpt:  [+2459.8% +2472.3% +2488.7%]
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe
```

For python SDK, regex benchmark used to be 5x slower than native python sdk. Now it is 14x faster:
```
+----------------------------------+---------+-----------------------+-----------------------+
| Benchmark                        | 3.7.0   | 4.0.0-old             | 4.0.0                 |
+==================================+=========+=======================+=======================+
| Evaluation (sdk-test-data)       | 14.3 us | 7.10 us: 2.01x faster | 3.75 us: 3.81x faster |
+----------------------------------+---------+-----------------------+-----------------------+
| Evaluation (new-user-onboarding) | 9.27 us | 2.37 us: 3.92x faster | 361 ns: 25.67x faster |
+----------------------------------+---------+-----------------------+-----------------------+
| Evaluation (numeric-one-of)      | 9.77 us | 774 ns: 12.62x faster | 771 ns: 12.67x faster |
+----------------------------------+---------+-----------------------+-----------------------+
| Evaluation (regex-flag)          | 8.43 us | 46.1 us: 5.47x slower | 567 ns: 14.86x faster |
+----------------------------------+---------+-----------------------+-----------------------+

```