### PR TITLE
refactor(all),fix(rust): introduce Evaluator and handle SdkMetadata

### DIFF
--- a/eppo_core/benches/evaluation_details.rs
+++ b/eppo_core/benches/evaluation_details.rs
@@ -1,17 +1,23 @@
 use std::collections::HashMap;
 use std::fs::File;
 
+use chrono::Utc;
 use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
 
 use eppo_core::{
     eval::{get_assignment, get_assignment_details},
-    Configuration,
+    Configuration, SdkMetadata,
 };
 
 fn criterion_benchmark(c: &mut Criterion) {
     let flags =
         serde_json::from_reader(File::open("../sdk-test-data/ufc/flags-v1.json").unwrap()).unwrap();
     let configuration = Configuration::from_server_response(flags, None);
+    let now = Utc::now();
+    let meta = SdkMetadata {
+        name: "test",
+        version: "0.1.0",
+    };
 
     {
         let mut group = c.benchmark_group("new-user-onboarding");
@@ -25,6 +31,8 @@ fn criterion_benchmark(c: &mut Criterion) {
                     black_box("subject1"),
                     black_box(&attributes),
                     black_box(None),
+                    black_box(now),
+                    &meta,
                 )
             })
         });
@@ -36,6 +44,8 @@ fn criterion_benchmark(c: &mut Criterion) {
                     black_box("subject1"),
                     black_box(&attributes),
                     black_box(None),
+                    black_box(now),
+                    &meta,
                 )
             })
         });
@@ -54,6 +64,8 @@ fn criterion_benchmark(c: &mut Criterion) {
                     black_box("subject1"),
                     black_box(&attributes),
                     black_box(None),
+                    black_box(now),
+                    &meta,
                 )
             })
         });
@@ -65,6 +77,8 @@ fn criterion_benchmark(c: &mut Criterion) {
                     black_box("subject1"),
                     black_box(&attributes),
                     black_box(None),
+                    black_box(now),
+                    &meta,
                 )
             })
         });
@@ -83,6 +97,8 @@ fn criterion_benchmark(c: &mut Criterion) {
                     black_box("subject1"),
                     black_box(&attributes),
                     black_box(None),
+                    black_box(now),
+                    &meta,
                 )
             })
         });
@@ -94,6 +110,8 @@ fn criterion_benchmark(c: &mut Criterion) {
                     black_box("subject1"),
                     black_box(&attributes),
                     black_box(None),
+                    black_box(now),
+                    &meta,
                 )
             })
         });
@@ -112,6 +130,8 @@ fn criterion_benchmark(c: &mut Criterion) {
                     black_box("subject1"),
                     black_box(&attributes),
                     black_box(None),
+                    black_box(now),
+                    &meta,
                 )
             })
         });
@@ -123,6 +143,8 @@ fn criterion_benchmark(c: &mut Criterion) {
                     black_box("subject1"),
                     black_box(&attributes),
                     black_box(None),
+                    black_box(now),
+                    &meta,
                 )
             })
         });
@@ -141,6 +163,8 @@ fn criterion_benchmark(c: &mut Criterion) {
                     black_box("subject1"),
                     black_box(&attributes),
                     black_box(None),
+                    black_box(now),
+                    &meta,
                 )
             })
         });
@@ -152,6 +176,8 @@ fn criterion_benchmark(c: &mut Criterion) {
                     black_box("subject1"),
                     black_box(&attributes),
                     black_box(None),
+                    black_box(now),
+                    &meta,
                 )
             })
         });

--- a/eppo_core/src/configuration_fetcher.rs
+++ b/eppo_core/src/configuration_fetcher.rs
@@ -1,16 +1,15 @@
 //! An HTTP client that fetches configuration from the server.
 use reqwest::{StatusCode, Url};
 
-use crate::{bandits::BanditResponse, ufc::UniversalFlagConfig, Configuration, Error, Result};
+use crate::{
+    bandits::BanditResponse, ufc::UniversalFlagConfig, Configuration, Error, Result, SdkMetadata,
+};
 
 #[derive(Debug, PartialEq, Eq)]
 pub struct ConfigurationFetcherConfig {
     pub base_url: String,
     pub api_key: String,
-    /// SDK name. (Usually, language name.)
-    pub sdk_name: String,
-    /// Version of SDK.
-    pub sdk_version: String,
+    pub sdk_metadata: SdkMetadata,
 }
 
 pub const DEFAULT_BASE_URL: &'static str = "https://fscdn.eppo.cloud/api";
@@ -61,8 +60,8 @@ impl ConfigurationFetcher {
             &format!("{}{}", self.config.base_url, UFC_ENDPOINT),
             &[
                 ("apiKey", &*self.config.api_key),
-                ("sdkName", &*self.config.sdk_name),
-                ("sdkVersion", &*self.config.sdk_version),
+                ("sdkName", self.config.sdk_metadata.name),
+                ("sdkVersion", self.config.sdk_metadata.version),
                 ("coreVersion", env!("CARGO_PKG_VERSION")),
             ],
         )
@@ -95,8 +94,8 @@ impl ConfigurationFetcher {
             &format!("{}{}", self.config.base_url, BANDIT_ENDPOINT),
             &[
                 ("apiKey", &*self.config.api_key),
-                ("sdkName", &*self.config.sdk_name),
-                ("sdkVersion", &*self.config.sdk_version),
+                ("sdkName", self.config.sdk_metadata.name),
+                ("sdkVersion", self.config.sdk_metadata.version),
                 ("coreVersion", env!("CARGO_PKG_VERSION")),
             ],
         )

--- a/eppo_core/src/eval/evaluator.rs
+++ b/eppo_core/src/eval/evaluator.rs
@@ -1,0 +1,120 @@
+use std::{collections::HashMap, sync::Arc};
+
+use chrono::Utc;
+
+use crate::{
+    configuration_store::ConfigurationStore,
+    events::AssignmentEvent,
+    ufc::{Assignment, AssignmentValue, VariationType},
+    Attributes, Configuration, ContextAttributes, EvaluationError, SdkMetadata,
+};
+
+use super::{
+    eval_details::{EvaluationDetails, EvaluationResultWithDetails},
+    get_assignment, get_assignment_details, get_bandit_action, get_bandit_action_details,
+    BanditResult,
+};
+
+pub struct EvaluatorConfig {
+    pub configuration_store: Arc<ConfigurationStore>,
+    pub sdk_metadata: SdkMetadata,
+}
+
+/// Evaluator simplifies calling into evaluation functions and automatically adds necessary metadata
+/// to events (SDK name and version).
+pub struct Evaluator {
+    config: EvaluatorConfig,
+}
+
+impl Evaluator {
+    pub fn new(config: EvaluatorConfig) -> Evaluator {
+        Evaluator { config }
+    }
+
+    pub fn get_assignment(
+        &self,
+        flag_key: &str,
+        subject_key: &str,
+        subject_attributes: &Attributes,
+        expected_type: Option<VariationType>,
+    ) -> Result<Option<Assignment>, EvaluationError> {
+        let config = self.get_configuration();
+        get_assignment(
+            config.as_ref().map(AsRef::as_ref),
+            &flag_key,
+            &subject_key,
+            &subject_attributes,
+            expected_type,
+            Utc::now(),
+            &self.config.sdk_metadata,
+        )
+    }
+
+    pub fn get_assignment_details(
+        &self,
+        flag_key: &str,
+        subject_key: &str,
+        subject_attributes: &Attributes,
+        expected_type: Option<VariationType>,
+    ) -> (
+        EvaluationResultWithDetails<AssignmentValue>,
+        Option<AssignmentEvent>,
+    ) {
+        let config = self.get_configuration();
+        get_assignment_details(
+            config.as_ref().map(AsRef::as_ref),
+            &flag_key,
+            &subject_key,
+            &subject_attributes,
+            expected_type,
+            Utc::now(),
+            &self.config.sdk_metadata,
+        )
+    }
+
+    pub fn get_bandit_action(
+        &self,
+        flag_key: &str,
+        subject_key: &str,
+        subject_attributes: &ContextAttributes,
+        actions: &HashMap<String, ContextAttributes>,
+        default_variation: &str,
+    ) -> BanditResult {
+        let configuration = self.get_configuration();
+        get_bandit_action(
+            configuration.as_ref().map(|it| it.as_ref()),
+            flag_key,
+            subject_key,
+            subject_attributes,
+            actions,
+            default_variation,
+            Utc::now(),
+            &self.config.sdk_metadata,
+        )
+    }
+
+    pub fn get_bandit_action_details(
+        &self,
+        flag_key: &str,
+        subject_key: &str,
+        subject_attributes: &ContextAttributes,
+        actions: &HashMap<String, ContextAttributes>,
+        default_variation: &str,
+    ) -> (BanditResult, EvaluationDetails) {
+        let configuration = self.get_configuration();
+        get_bandit_action_details(
+            configuration.as_ref().map(|it| it.as_ref()),
+            flag_key,
+            subject_key,
+            subject_attributes,
+            actions,
+            default_variation,
+            Utc::now(),
+            &self.config.sdk_metadata,
+        )
+    }
+
+    fn get_configuration(&self) -> Option<Arc<Configuration>> {
+        self.config.configuration_store.get_configuration()
+    }
+}

--- a/eppo_core/src/eval/mod.rs
+++ b/eppo_core/src/eval/mod.rs
@@ -3,8 +3,10 @@ mod eval_bandits;
 mod eval_details_builder;
 mod eval_rules;
 mod eval_visitor;
+mod evaluator;
 
 pub mod eval_details;
 
 pub use eval_assignment::{get_assignment, get_assignment_details};
 pub use eval_bandits::{get_bandit_action, get_bandit_action_details, BanditResult};
+pub use evaluator::{Evaluator, EvaluatorConfig};

--- a/eppo_core/src/lib.rs
+++ b/eppo_core/src/lib.rs
@@ -29,8 +29,10 @@ mod attributes;
 mod configuration;
 mod context_attributes;
 mod error;
+mod sdk_metadata;
 
 pub use attributes::{AttributeValue, Attributes};
 pub use configuration::Configuration;
 pub use context_attributes::ContextAttributes;
 pub use error::{Error, EvaluationError, Result};
+pub use sdk_metadata::SdkMetadata;

--- a/eppo_core/src/sdk_metadata.rs
+++ b/eppo_core/src/sdk_metadata.rs
@@ -1,0 +1,10 @@
+/// SDK metadata that is used in a couple of places:
+/// - added to assignment and bandit events
+/// - sent in query when requesting config
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SdkMetadata {
+    /// SDK name. (Usually, language name.)
+    pub name: &'static str,
+    /// Version of SDK.
+    pub version: &'static str,
+}

--- a/ruby-sdk/lib/eppo_client/client.rb
+++ b/ruby-sdk/lib/eppo_client/client.rb
@@ -144,7 +144,6 @@ module EppoClient
       # events for both flag assignment and bandit actions.
       event = event.to_h { |key, value| [key.to_sym, value]}
 
-      enrich_event_metadata(event)
       begin
         @assignment_logger.log_assignment(event)
       rescue EppoClient::AssignmentLoggerError
@@ -158,7 +157,6 @@ module EppoClient
     def log_bandit_action(event)
       if not event then return end
 
-      enrich_event_metadata(event)
       begin
         @assignment_logger.log_bandit_action(event)
       rescue EppoClient::AssignmentLoggerError
@@ -167,11 +165,6 @@ module EppoClient
         logger = Logger.new($stdout)
         logger.error("[Eppo SDK] Error logging bandit action event: #{error}")
       end
-    end
-
-    def enrich_event_metadata(event)
-      event[:metaData]["sdkName"] = "ruby"
-      event[:metaData]["sdkVersion"] = EppoClient::VERSION
     end
 
     def coerce_context_attributes(attributes)

--- a/rust-sdk/Cargo.toml
+++ b/rust-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eppo"
-version = "3.0.0"
+version = "3.0.1"
 edition = "2021"
 description = "Eppo SDK for Rust"
 homepage = "https://docs.geteppo.com/sdks/server-sdks/rust"

--- a/rust-sdk/src/lib.rs
+++ b/rust-sdk/src/lib.rs
@@ -60,6 +60,7 @@ mod client;
 mod config;
 mod poller;
 
+use eppo_core::SdkMetadata;
 #[doc(inline)]
 pub use eppo_core::{
     eval::eval_details::*, events::AssignmentEvent, ufc::AssignmentValue, AttributeValue,
@@ -70,3 +71,8 @@ pub use assignment_logger::AssignmentLogger;
 pub use client::Client;
 pub use config::ClientConfig;
 pub use poller::PollerThread;
+
+pub(crate) const SDK_METADATA: SdkMetadata = SdkMetadata {
+    name: "rust",
+    version: env!("CARGO_PKG_VERSION"),
+};

--- a/rust-sdk/src/poller.rs
+++ b/rust-sdk/src/poller.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use crate::Result;
+use crate::{Result, SDK_METADATA};
 use eppo_core::configuration_fetcher::{ConfigurationFetcher, ConfigurationFetcherConfig};
 use eppo_core::configuration_store::ConfigurationStore;
 use eppo_core::poller_thread::PollerThread as PollerThreadImpl;
@@ -46,8 +46,7 @@ impl PollerThread {
         let fetcher = ConfigurationFetcher::new(ConfigurationFetcherConfig {
             base_url: config.base_url,
             api_key: config.api_key,
-            sdk_name: "rust".to_owned(),
-            sdk_version: env!("CARGO_PKG_VERSION").to_owned(),
+            sdk_metadata: SDK_METADATA.clone(),
         });
         let inner = PollerThreadImpl::start(fetcher, config.store)?;
         Ok(PollerThread(inner))


### PR DESCRIPTION
Previously, eppo_core did not set metadata on events correctly (sdk name and version were missing). Python and rust accounted for this separately, and Rust didn't handle it at all.

This PR makes evaluation function take SdkMetadata as a parameter, so it's now impossible to miss.

`now` is not also a parameter, so all evaluation functions are now pure functions without side effects, so we can add time-based tests in the future.

This PR also introduces Evaluator to simplify calling into evaluator functions for upstream SDKs.