### PR TITLE
chore: unbump rust-sdk

### DIFF
--- a/rust-sdk/Cargo.toml
+++ b/rust-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eppo"
-version = "3.0.2"
+version = "3.0.1"
 edition = "2021"
 description = "Eppo SDK for Rust"
 homepage = "https://docs.geteppo.com/sdks/server-sdks/rust"


### PR DESCRIPTION
3.0.1 hasn't been released yet.