### PR TITLE
FF-3205 perf: minimize copying and a bunch of other optimizations

### DIFF
--- a/eppo_core/Cargo.toml
+++ b/eppo_core/Cargo.toml
@@ -16,6 +16,7 @@ pyo3 = ["dep:pyo3", "dep:serde-pyobject"]
 [dependencies]
 chrono = { version = "0.4.38", features = ["serde"] }
 derive_more = "0.99.17"
+faststr = { version = "0.2.23", features = ["serde"] }
 log = { version = "0.4.21", features = ["kv", "kv_serde"] }
 md5 = "0.7.0"
 rand = "0.8.5"
@@ -30,7 +31,6 @@ url = "2.5.0"
 # pyo3 dependencies
 pyo3 = { version = "0.22.0", optional = true, default-features = false }
 serde-pyobject = { version = "0.4.0", optional = true}
-faststr = { version = "0.2.23", features = ["serde"] }
 
 [dev-dependencies]
 criterion = { version = "0.4", features = ["html_reports"] }

--- a/eppo_core/Cargo.toml
+++ b/eppo_core/Cargo.toml
@@ -30,6 +30,7 @@ url = "2.5.0"
 # pyo3 dependencies
 pyo3 = { version = "0.22.0", optional = true, default-features = false }
 serde-pyobject = { version = "0.4.0", optional = true}
+faststr = { version = "0.2.23", features = ["serde"] }
 
 [dev-dependencies]
 criterion = { version = "0.4", features = ["html_reports"] }

--- a/eppo_core/Cargo.toml
+++ b/eppo_core/Cargo.toml
@@ -22,7 +22,7 @@ rand = "0.8.5"
 regex = "1.10.4"
 reqwest = { version = "0.12.4", features = ["blocking", "json"] }
 semver = { version = "1.0.22", features = ["serde"] }
-serde = { version = "1.0.198", features = ["derive"] }
+serde = { version = "1.0.198", features = ["derive", "rc"] }
 serde_json = "1.0.116"
 thiserror = "1.0.60"
 url = "2.5.0"

--- a/eppo_core/benches/evaluation_details.rs
+++ b/eppo_core/benches/evaluation_details.rs
@@ -1,5 +1,5 @@
-use std::collections::HashMap;
 use std::fs::File;
+use std::{collections::HashMap, sync::Arc};
 
 use chrono::Utc;
 use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
@@ -22,13 +22,13 @@ fn criterion_benchmark(c: &mut Criterion) {
     {
         let mut group = c.benchmark_group("new-user-onboarding");
         group.throughput(Throughput::Elements(1));
-        let attributes = HashMap::new();
+        let attributes = Arc::new(HashMap::new());
         group.bench_function("get_assignment", |b| {
             b.iter(|| {
                 get_assignment(
                     black_box(Some(&configuration)),
                     black_box("new-user-onboarding"),
-                    black_box("subject1"),
+                    black_box(&"subject1".into()),
                     black_box(&attributes),
                     black_box(None),
                     black_box(now),
@@ -41,7 +41,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                 get_assignment_details(
                     black_box(Some(&configuration)),
                     black_box("new-user-onboarding"),
-                    black_box("subject1"),
+                    black_box(&"subject1".into()),
                     black_box(&attributes),
                     black_box(None),
                     black_box(now),
@@ -55,13 +55,13 @@ fn criterion_benchmark(c: &mut Criterion) {
     {
         let mut group = c.benchmark_group("rollout");
         group.throughput(Throughput::Elements(1));
-        let attributes = [("country".to_owned(), "US".into())].into();
+        let attributes = Arc::new([("country".to_owned(), "US".into())].into());
         group.bench_function("get_assignment", |b| {
             b.iter(|| {
                 get_assignment(
                     black_box(Some(&configuration)),
                     black_box("new-user-onboarding"),
-                    black_box("subject1"),
+                    black_box(&"subject1".into()),
                     black_box(&attributes),
                     black_box(None),
                     black_box(now),
@@ -74,7 +74,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                 get_assignment_details(
                     black_box(Some(&configuration)),
                     black_box("new-user-onboarding"),
-                    black_box("subject1"),
+                    black_box(&"subject1".into()),
                     black_box(&attributes),
                     black_box(None),
                     black_box(now),
@@ -88,13 +88,13 @@ fn criterion_benchmark(c: &mut Criterion) {
     {
         let mut group = c.benchmark_group("json-config-flag");
         group.throughput(Throughput::Elements(1));
-        let attributes = [].into();
+        let attributes = Arc::new([].into());
         group.bench_function("get_assignment", |b| {
             b.iter(|| {
                 get_assignment(
                     black_box(Some(&configuration)),
                     black_box("json-config-flag"),
-                    black_box("subject1"),
+                    black_box(&"subject1".into()),
                     black_box(&attributes),
                     black_box(None),
                     black_box(now),
@@ -107,7 +107,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                 get_assignment_details(
                     black_box(Some(&configuration)),
                     black_box("json-config-flag"),
-                    black_box("subject1"),
+                    black_box(&"subject1".into()),
                     black_box(&attributes),
                     black_box(None),
                     black_box(now),
@@ -121,13 +121,13 @@ fn criterion_benchmark(c: &mut Criterion) {
     {
         let mut group = c.benchmark_group("numeric-one-of");
         group.throughput(Throughput::Elements(1));
-        let attributes = [("number".to_owned(), 2.0.into())].into();
+        let attributes = Arc::new([("number".to_owned(), 2.0.into())].into());
         group.bench_function("get_assignment", |b| {
             b.iter(|| {
                 get_assignment(
                     black_box(Some(&configuration)),
                     black_box("numeric-one-of"),
-                    black_box("subject1"),
+                    black_box(&"subject1".into()),
                     black_box(&attributes),
                     black_box(None),
                     black_box(now),
@@ -140,7 +140,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                 get_assignment_details(
                     black_box(Some(&configuration)),
                     black_box("numeric-one-of"),
-                    black_box("subject1"),
+                    black_box(&"subject1".into()),
                     black_box(&attributes),
                     black_box(None),
                     black_box(now),
@@ -154,13 +154,13 @@ fn criterion_benchmark(c: &mut Criterion) {
     {
         let mut group = c.benchmark_group("regex-flag");
         group.throughput(Throughput::Elements(1));
-        let attributes = [("email".into(), "test@gmail.com".into())].into();
+        let attributes = Arc::new([("email".into(), "test@gmail.com".into())].into());
         group.bench_function("get_assignment", |b| {
             b.iter(|| {
                 get_assignment(
                     black_box(Some(&configuration)),
                     black_box("regex-flag"),
-                    black_box("subject1"),
+                    black_box(&"subject1".into()),
                     black_box(&attributes),
                     black_box(None),
                     black_box(now),
@@ -173,7 +173,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                 get_assignment_details(
                     black_box(Some(&configuration)),
                     black_box("regex-flag"),
-                    black_box("subject1"),
+                    black_box(&"subject1".into()),
                     black_box(&attributes),
                     black_box(None),
                     black_box(now),

--- a/eppo_core/benches/evaluation_details.rs
+++ b/eppo_core/benches/evaluation_details.rs
@@ -1,23 +1,25 @@
-use std::fs::File;
 use std::{collections::HashMap, sync::Arc};
 
 use chrono::Utc;
 use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
 
+use eppo_core::ufc::UniversalFlagConfig;
 use eppo_core::{
     eval::{get_assignment, get_assignment_details},
     Configuration, SdkMetadata,
 };
 
 fn criterion_benchmark(c: &mut Criterion) {
-    let flags =
-        serde_json::from_reader(File::open("../sdk-test-data/ufc/flags-v1.json").unwrap()).unwrap();
+    let flags = UniversalFlagConfig::from_json(
+        SdkMetadata {
+            name: "test",
+            version: "0.1.0",
+        },
+        std::fs::read("../sdk-test-data/ufc/flags-v1.json").unwrap(),
+    )
+    .unwrap();
     let configuration = Configuration::from_server_response(flags, None);
     let now = Utc::now();
-    let meta = SdkMetadata {
-        name: "test",
-        version: "0.1.0",
-    };
 
     {
         let mut group = c.benchmark_group("new-user-onboarding");
@@ -32,7 +34,6 @@ fn criterion_benchmark(c: &mut Criterion) {
                     black_box(&attributes),
                     black_box(None),
                     black_box(now),
-                    &meta,
                 )
             })
         });
@@ -45,7 +46,6 @@ fn criterion_benchmark(c: &mut Criterion) {
                     black_box(&attributes),
                     black_box(None),
                     black_box(now),
-                    &meta,
                 )
             })
         });
@@ -65,7 +65,6 @@ fn criterion_benchmark(c: &mut Criterion) {
                     black_box(&attributes),
                     black_box(None),
                     black_box(now),
-                    &meta,
                 )
             })
         });
@@ -78,7 +77,6 @@ fn criterion_benchmark(c: &mut Criterion) {
                     black_box(&attributes),
                     black_box(None),
                     black_box(now),
-                    &meta,
                 )
             })
         });
@@ -98,7 +96,6 @@ fn criterion_benchmark(c: &mut Criterion) {
                     black_box(&attributes),
                     black_box(None),
                     black_box(now),
-                    &meta,
                 )
             })
         });
@@ -111,7 +108,6 @@ fn criterion_benchmark(c: &mut Criterion) {
                     black_box(&attributes),
                     black_box(None),
                     black_box(now),
-                    &meta,
                 )
             })
         });
@@ -131,7 +127,6 @@ fn criterion_benchmark(c: &mut Criterion) {
                     black_box(&attributes),
                     black_box(None),
                     black_box(now),
-                    &meta,
                 )
             })
         });
@@ -144,7 +139,6 @@ fn criterion_benchmark(c: &mut Criterion) {
                     black_box(&attributes),
                     black_box(None),
                     black_box(now),
-                    &meta,
                 )
             })
         });
@@ -164,7 +158,6 @@ fn criterion_benchmark(c: &mut Criterion) {
                     black_box(&attributes),
                     black_box(None),
                     black_box(now),
-                    &meta,
                 )
             })
         });
@@ -177,7 +170,6 @@ fn criterion_benchmark(c: &mut Criterion) {
                     black_box(&attributes),
                     black_box(None),
                     black_box(now),
-                    &meta,
                 )
             })
         });

--- a/eppo_core/src/attributes.rs
+++ b/eppo_core/src/attributes.rs
@@ -115,7 +115,7 @@ mod pyo3_impl {
                 return Ok(AttributeValue::Boolean(s.is_true()));
             }
             if let Ok(s) = value.downcast::<PyFloat>() {
-                return Ok(AttributeValue::Number(s.extract()?));
+                return Ok(AttributeValue::Number(s.value()));
             }
             if let Ok(s) = value.downcast::<PyInt>() {
                 return Ok(AttributeValue::Number(s.extract()?));

--- a/eppo_core/src/attributes.rs
+++ b/eppo_core/src/attributes.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, sync::Arc};
 use derive_more::From;
 use serde::{Deserialize, Serialize};
 
-use crate::ArcStr;
+use crate::Str;
 
 /// `Subject` is a bundle of subject attributes and a key.
 #[derive(Debug)]
@@ -15,14 +15,14 @@ pub(crate) struct Subject {
 }
 
 impl Subject {
-    pub fn new(key: ArcStr, attributes: Arc<Attributes>) -> Subject {
+    pub fn new(key: Str, attributes: Arc<Attributes>) -> Subject {
         Subject {
             key: AttributeValue::String(key),
             attributes,
         }
     }
 
-    pub fn key(&self) -> &ArcStr {
+    pub fn key(&self) -> &Str {
         let AttributeValue::String(s) = &self.key else {
             unreachable!("Subject::key is always encoded as AttributeValue::ArcString()");
         };
@@ -74,7 +74,7 @@ pub type Attributes = HashMap<String, AttributeValue>;
 pub enum AttributeValue {
     /// A string value.
     #[from(ignore)]
-    String(ArcStr),
+    String(Str),
     /// A numerical value.
     Number(f64),
     /// A boolean value.
@@ -83,7 +83,7 @@ pub enum AttributeValue {
     Null,
 }
 
-impl<T: Into<ArcStr>> From<T> for AttributeValue {
+impl<T: Into<Str>> From<T> for AttributeValue {
     fn from(value: T) -> AttributeValue {
         AttributeValue::String(value.into())
     }

--- a/eppo_core/src/configuration.rs
+++ b/eppo_core/src/configuration.rs
@@ -1,14 +1,14 @@
-use std::collections::HashMap;
+use std::collections::HashSet;
 
 use chrono::{DateTime, Utc};
 
 use crate::{
     bandits::{BanditConfiguration, BanditResponse},
-    ufc::{BanditVariation, TryParse, UniversalFlagConfig},
+    ufc::UniversalFlagConfig,
 };
 
 /// Remote configuration for the eppo client. It's a central piece that defines client behavior.
-#[derive(Clone)]
+#[derive(Debug)]
 pub struct Configuration {
     /// Timestamp when configuration was fetched by the SDK.
     pub fetched_at: DateTime<Utc>,
@@ -16,10 +16,6 @@ pub struct Configuration {
     pub flags: UniversalFlagConfig,
     /// Bandits configuration.
     pub bandits: Option<BanditResponse>,
-    /// Mapping from flag key to flag variation value to bandit variation. Cached from
-    /// `self.flags.bandits`.
-    pub flag_to_bandit_associations:
-        HashMap</* flag_key: */ String, HashMap</* variation_key: */ String, BanditVariation>>,
 }
 
 impl Configuration {
@@ -30,26 +26,18 @@ impl Configuration {
     ) -> Configuration {
         let now = Utc::now();
 
-        // warn if some flags failed to parse
-        for (name, flag) in &config.flags {
-            if let TryParse::ParseFailed(_value) = flag {
-                log::warn!(target: "eppo", "failed to parse flag configuration: {name:?}");
-            }
-        }
-
-        let flag_to_bandit_associations = get_flag_to_bandit_associations(&config);
-
         Configuration {
             fetched_at: now,
             flags: config,
             bandits,
-            flag_to_bandit_associations,
         }
     }
 
     /// Return a bandit variant for the specified flag key and string flag variation.
     pub(crate) fn get_bandit_key<'a>(&'a self, flag_key: &str, variation: &str) -> Option<&'a str> {
-        self.flag_to_bandit_associations
+        self.flags
+            .compiled
+            .flag_to_bandit_associations
             .get(flag_key)
             .and_then(|x| x.get(variation))
             .map(|variation| variation.key.as_str())
@@ -61,19 +49,10 @@ impl Configuration {
     pub(crate) fn get_bandit<'a>(&'a self, bandit_key: &str) -> Option<&'a BanditConfiguration> {
         self.bandits.as_ref()?.bandits.get(bandit_key)
     }
-}
 
-fn get_flag_to_bandit_associations(
-    config: &UniversalFlagConfig,
-) -> HashMap<String, HashMap<String, BanditVariation>> {
-    config
-        .bandits
-        .iter()
-        .flat_map(|(_, bandits)| bandits.iter())
-        .fold(HashMap::new(), |mut acc, variation| {
-            acc.entry(variation.flag_key.clone())
-                .or_default()
-                .insert(variation.variation_value.clone(), variation.clone());
-            acc
-        })
+    /// Get a set of all available flags. Note that this may return both disabled flags and flags
+    /// with bad configuration.
+    pub fn flag_keys(&self) -> HashSet<String> {
+        self.flags.compiled.flags.keys().cloned().collect()
+    }
 }

--- a/eppo_core/src/configuration_fetcher.rs
+++ b/eppo_core/src/configuration_fetcher.rs
@@ -45,7 +45,7 @@ impl ConfigurationFetcher {
 
         let ufc = self.fetch_ufc_configuration()?;
 
-        let bandits = if ufc.bandits.is_empty() {
+        let bandits = if ufc.compiled.flag_to_bandit_associations.is_empty() {
             // We don't need bandits configuration if there are no bandits.
             None
         } else {
@@ -82,7 +82,8 @@ impl ConfigurationFetcher {
             }
         })?;
 
-        let configuration = response.json()?;
+        let configuration =
+            UniversalFlagConfig::from_json(self.config.sdk_metadata, response.bytes()?.into())?;
 
         log::debug!(target: "eppo", "successfully fetched UFC flags configuration");
 

--- a/eppo_core/src/configuration_store.rs
+++ b/eppo_core/src/configuration_store.rs
@@ -67,7 +67,7 @@ mod tests {
             let _ = std::thread::spawn(move || {
                 store.set_configuration(Arc::new(Configuration::from_server_response(
                     UniversalFlagConfig {
-                        wire_json: Vec::from(b"test-bytes"),
+                        wire_json: b"test-bytes".to_vec(),
                         compiled: CompiledFlagsConfig {
                             created_at: Utc::now(),
                             environment: Environment {

--- a/eppo_core/src/configuration_store.rs
+++ b/eppo_core/src/configuration_store.rs
@@ -69,7 +69,7 @@ mod tests {
                     UniversalFlagConfig {
                         created_at: Utc::now(),
                         environment: Environment {
-                            name: "test".to_owned(),
+                            name: "test".into(),
                         },
                         flags: HashMap::new(),
                         bandits: HashMap::new(),

--- a/eppo_core/src/configuration_store.rs
+++ b/eppo_core/src/configuration_store.rs
@@ -52,7 +52,7 @@ mod tests {
 
     use super::ConfigurationStore;
     use crate::{
-        ufc::{Environment, UniversalFlagConfig},
+        ufc::{CompiledFlagsConfig, Environment, UniversalFlagConfig},
         Configuration,
     };
 
@@ -67,12 +67,15 @@ mod tests {
             let _ = std::thread::spawn(move || {
                 store.set_configuration(Arc::new(Configuration::from_server_response(
                     UniversalFlagConfig {
-                        created_at: Utc::now(),
-                        environment: Environment {
-                            name: "test".into(),
+                        wire_json: Vec::from(b"test-bytes"),
+                        compiled: CompiledFlagsConfig {
+                            created_at: Utc::now(),
+                            environment: Environment {
+                                name: "test".into(),
+                            },
+                            flags: HashMap::new(),
+                            flag_to_bandit_associations: HashMap::new(),
                         },
-                        flags: HashMap::new(),
-                        bandits: HashMap::new(),
                     },
                     None,
                 )))

--- a/eppo_core/src/context_attributes.rs
+++ b/eppo_core/src/context_attributes.rs
@@ -50,8 +50,10 @@ where
                         // We can go a step further and remove `AttributeValue::Boolean` altogether
                         // (from `eppo_core`), forcing it to be converted to a string before any
                         // evaluation.
-                        acc.categorical
-                            .insert(key.to_owned(), value.to_string().into());
+                        acc.categorical.insert(
+                            key.to_owned(),
+                            Str::from_static_str(if value { "true" } else { "false" }),
+                        );
                     }
                     AttributeValue::Null => {
                         // Nulls are missing values and are ignored.

--- a/eppo_core/src/context_attributes.rs
+++ b/eppo_core/src/context_attributes.rs
@@ -36,6 +36,10 @@ where
         iter.into_iter()
             .fold(ContextAttributes::default(), |mut acc, (key, value)| {
                 match value.to_owned() {
+                    AttributeValue::ArcString(value) => {
+                        acc.categorical
+                            .insert(key.to_owned(), value.as_ref().into());
+                    }
                     AttributeValue::String(value) => {
                         acc.categorical.insert(key.to_owned(), value);
                     }

--- a/eppo_core/src/context_attributes.rs
+++ b/eppo_core/src/context_attributes.rs
@@ -36,12 +36,9 @@ where
         iter.into_iter()
             .fold(ContextAttributes::default(), |mut acc, (key, value)| {
                 match value.to_owned() {
-                    AttributeValue::ArcString(value) => {
+                    AttributeValue::String(value) => {
                         acc.categorical
                             .insert(key.to_owned(), value.as_ref().into());
-                    }
-                    AttributeValue::String(value) => {
-                        acc.categorical.insert(key.to_owned(), value);
                     }
                     AttributeValue::Number(value) => {
                         acc.numeric.insert(key.to_owned(), value);
@@ -73,7 +70,7 @@ impl ContextAttributes {
             result.insert(key.clone(), AttributeValue::Number(*value));
         }
         for (key, value) in self.categorical.iter() {
-            result.insert(key.clone(), AttributeValue::String(value.clone()));
+            result.insert(key.clone(), AttributeValue::String(value.as_str().into()));
         }
         result
     }

--- a/eppo_core/src/context_attributes.rs
+++ b/eppo_core/src/context_attributes.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
 
-use crate::{ArcStr, AttributeValue, Attributes};
+use crate::{AttributeValue, Attributes, Str};
 
 /// `ContextAttributes` are subject or action attributes split by their semantics.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -18,7 +18,7 @@ pub struct ContextAttributes {
     /// Categorical attributes are attributes that have a finite set of values that are not directly
     /// comparable (i.e., enumeration).
     #[serde(alias = "categoricalAttributes")]
-    pub categorical: HashMap<String, ArcStr>,
+    pub categorical: HashMap<String, Str>,
 }
 
 impl From<Attributes> for ContextAttributes {
@@ -82,7 +82,7 @@ mod pyo3_impl {
 
     use pyo3::prelude::*;
 
-    use crate::{ArcStr, Attributes};
+    use crate::{Attributes, Str};
 
     use super::ContextAttributes;
 
@@ -91,7 +91,7 @@ mod pyo3_impl {
         #[new]
         fn new(
             numeric_attributes: HashMap<String, f64>,
-            categorical_attributes: HashMap<String, ArcStr>,
+            categorical_attributes: HashMap<String, Str>,
         ) -> ContextAttributes {
             ContextAttributes {
                 numeric: numeric_attributes,

--- a/eppo_core/src/eval/eval_assignment.rs
+++ b/eppo_core/src/eval/eval_assignment.rs
@@ -81,7 +81,7 @@ pub fn get_assignment_details(
         None => (None, None),
     };
 
-    let evaluation_details = details_builder.build();
+    let evaluation_details = Arc::new(details_builder.build());
 
     if let Some(event) = &mut event {
         event.evaluation_details = Some(evaluation_details.clone());
@@ -448,10 +448,10 @@ mod tests {
         pub order_position: usize,
         pub allocation_evaluation_code: AllocationEvaluationCode,
     }
-    impl From<AllocationEvaluationDetails> for TruncatedAllocationEvaluationDetails {
-        fn from(value: AllocationEvaluationDetails) -> Self {
+    impl From<&AllocationEvaluationDetails> for TruncatedAllocationEvaluationDetails {
+        fn from(value: &AllocationEvaluationDetails) -> Self {
             Self {
-                key: value.key,
+                key: value.key.clone(),
                 order_position: value.order_position,
                 allocation_evaluation_code: value.allocation_evaluation_code,
             }
@@ -584,7 +584,7 @@ mod tests {
                     Vec::new();
                 let mut unevaluated_allocations: Vec<TruncatedAllocationEvaluationDetails> =
                     Vec::new();
-                for allocation in actual.allocations {
+                for allocation in &actual.allocations {
                     match allocation.allocation_evaluation_code {
                         AllocationEvaluationCode::Unevaluated => {
                             unevaluated_allocations.push(allocation.into())

--- a/eppo_core/src/eval/eval_assignment.rs
+++ b/eppo_core/src/eval/eval_assignment.rs
@@ -275,7 +275,7 @@ impl Flag {
             variation: variation.key.clone(),
             subject: subject_key.to_owned(),
             subject_attributes: subject_attributes.clone(),
-            timestamp: now.to_rfc3339(),
+            timestamp: now,
             meta_data: [
                 ("sdkName".to_owned(), meta.name.to_owned()),
                 ("sdkVersion".to_owned(), meta.version.to_owned()),
@@ -389,7 +389,7 @@ mod tests {
             get_assignment, get_assignment_details,
         },
         ufc::{Rule, TryParse, UniversalFlagConfig, Value, VariationType},
-        Attributes, Configuration, SdkMetadata,
+        ArcStr, Attributes, Configuration, SdkMetadata,
     };
 
     #[derive(Debug, Serialize, Deserialize)]
@@ -414,7 +414,7 @@ mod tests {
     #[serde(rename_all = "camelCase")]
     struct TruncatedEvaluationDetails {
         /// Environment the configuration belongs to. None if configuration hasn't been fetched yet.
-        environment_name: Option<String>,
+        environment_name: Option<ArcStr>,
 
         flag_evaluation_code: TruncatedFlagEvaluationCode,
         flag_evaluation_description: String,
@@ -456,7 +456,7 @@ mod tests {
     #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
     #[serde(rename_all = "camelCase")]
     pub struct TruncatedAllocationEvaluationDetails {
-        pub key: String,
+        pub key: ArcStr,
         /// Order position of the allocation as seen in the Web UI.
         pub order_position: usize,
         pub allocation_evaluation_code: AllocationEvaluationCode,

--- a/eppo_core/src/eval/eval_assignment.rs
+++ b/eppo_core/src/eval/eval_assignment.rs
@@ -424,7 +424,9 @@ mod tests {
     fn to_value(value: DefaultValue) -> ValueWire {
         match value {
             DefaultValue::Value(v) => v,
-            DefaultValue::Json(json) => ValueWire::String(serde_json::to_string(&json).unwrap()),
+            DefaultValue::Json(json) => {
+                ValueWire::String(serde_json::to_string(&json).unwrap().as_str().into())
+            }
         }
     }
 
@@ -451,7 +453,7 @@ mod tests {
             let test_file: TestFile = serde_json::from_reader(f).unwrap();
 
             let default_assignment = to_value(test_file.default_value)
-                .to_assignment_value(test_file.variation_type)
+                .into_assignment_value(test_file.variation_type)
                 .unwrap();
 
             for subject in test_file.subjects {
@@ -471,7 +473,7 @@ mod tests {
                     .map(|assignment| &assignment.value)
                     .unwrap_or(&default_assignment);
                 let expected_assignment = to_value(subject.assignment)
-                    .to_assignment_value(test_file.variation_type)
+                    .into_assignment_value(test_file.variation_type)
                     .unwrap();
 
                 assert_eq!(result_assingment, &expected_assignment);

--- a/eppo_core/src/eval/eval_assignment.rs
+++ b/eppo_core/src/eval/eval_assignment.rs
@@ -29,7 +29,7 @@ pub fn get_assignment(
     subject_attributes: &Attributes,
     expected_type: Option<VariationType>,
     now: DateTime<Utc>,
-    meta: &SdkMetadata,
+    sdk_meta: &SdkMetadata,
 ) -> Result<Option<Assignment>, EvaluationError> {
     get_assignment_with_visitor(
         configuration,
@@ -39,7 +39,7 @@ pub fn get_assignment(
         subject_attributes,
         expected_type,
         now,
-        meta,
+        sdk_meta,
     )
 }
 
@@ -51,7 +51,7 @@ pub fn get_assignment_details(
     subject_attributes: &Attributes,
     expected_type: Option<VariationType>,
     now: DateTime<Utc>,
-    meta: &SdkMetadata,
+    sdk_meta: &SdkMetadata,
 ) -> (
     EvaluationResultWithDetails<AssignmentValue>,
     Option<AssignmentEvent>,
@@ -70,7 +70,7 @@ pub fn get_assignment_details(
         subject_attributes,
         expected_type,
         now,
-        meta,
+        sdk_meta,
     );
 
     let (value, mut event) = match result.unwrap_or_default() {
@@ -102,7 +102,7 @@ pub(super) fn get_assignment_with_visitor<V: EvalAssignmentVisitor>(
     subject_attributes: &Attributes,
     expected_type: Option<VariationType>,
     now: DateTime<Utc>,
-    meta: &SdkMetadata,
+    sdk_meta: &SdkMetadata,
 ) -> Result<Option<Assignment>, EvaluationError> {
     let result = if let Some(config) = configuration {
         visitor.on_configuration(config);
@@ -114,7 +114,7 @@ pub(super) fn get_assignment_with_visitor<V: EvalAssignmentVisitor>(
             &subject_attributes,
             expected_type,
             now,
-            meta,
+            sdk_meta,
         )
     } else {
         Err(EvaluationFailure::ConfigurationMissing)
@@ -171,7 +171,7 @@ impl UniversalFlagConfig {
         subject_attributes: &Attributes,
         expected_type: Option<VariationType>,
         now: DateTime<Utc>,
-        meta: &SdkMetadata,
+        sdk_meta: &SdkMetadata,
     ) -> Result<Assignment, EvaluationFailure> {
         let flag = self.get_flag(flag_key)?;
 
@@ -181,7 +181,7 @@ impl UniversalFlagConfig {
             flag.verify_type(ty)?;
         }
 
-        flag.eval(visitor, subject_key, subject_attributes, now, meta)
+        flag.eval(visitor, subject_key, subject_attributes, now, sdk_meta)
     }
 
     fn get_flag<'a>(&'a self, flag_key: &str) -> Result<&'a Flag, EvaluationFailure> {
@@ -217,7 +217,7 @@ impl Flag {
         subject_key: &str,
         subject_attributes: &Attributes,
         now: DateTime<Utc>,
-        meta: &SdkMetadata,
+        sdk_meta: &SdkMetadata,
     ) -> Result<Assignment, EvaluationFailure> {
         if !self.enabled {
             return Err(EvaluationFailure::FlagDisabled);
@@ -276,15 +276,7 @@ impl Flag {
             subject: subject_key.to_owned(),
             subject_attributes: subject_attributes.clone(),
             timestamp: now,
-            meta_data: [
-                ("sdkName".to_owned(), meta.name.to_owned()),
-                ("sdkVersion".to_owned(), meta.version.to_owned()),
-                (
-                    "eppoCoreVersion".to_owned(),
-                    env!("CARGO_PKG_VERSION").to_owned(),
-                ),
-            ]
-            .into(),
+            meta_data: sdk_meta.into(),
             extra_logging: split.extra_logging.clone(),
             evaluation_details: None,
         });

--- a/eppo_core/src/eval/eval_assignment.rs
+++ b/eppo_core/src/eval/eval_assignment.rs
@@ -10,7 +10,7 @@ use crate::{
         Allocation, Assignment, AssignmentValue, CompiledFlagsConfig, Flag, Shard, Split,
         Timestamp, VariationType,
     },
-    ArcStr, Attributes, Configuration,
+    Attributes, Configuration, Str,
 };
 
 use super::{
@@ -27,7 +27,7 @@ use super::{
 pub fn get_assignment(
     configuration: Option<&Configuration>,
     flag_key: &str,
-    subject_key: &ArcStr,
+    subject_key: &Str,
     subject_attributes: &Arc<Attributes>,
     expected_type: Option<VariationType>,
     now: DateTime<Utc>,
@@ -47,7 +47,7 @@ pub fn get_assignment(
 pub fn get_assignment_details(
     configuration: Option<&Configuration>,
     flag_key: &str,
-    subject_key: &ArcStr,
+    subject_key: &Str,
     subject_attributes: &Arc<Attributes>,
     expected_type: Option<VariationType>,
     now: DateTime<Utc>,
@@ -96,7 +96,7 @@ pub(super) fn get_assignment_with_visitor<V: EvalAssignmentVisitor>(
     configuration: Option<&Configuration>,
     visitor: &mut V,
     flag_key: &str,
-    subject_key: &ArcStr,
+    subject_key: &Str,
     subject_attributes: &Arc<Attributes>,
     expected_type: Option<VariationType>,
     now: DateTime<Utc>,
@@ -163,7 +163,7 @@ impl CompiledFlagsConfig {
         &self,
         visitor: &mut V,
         flag_key: &str,
-        subject_key: &ArcStr,
+        subject_key: &Str,
         subject_attributes: &Arc<Attributes>,
         expected_type: Option<VariationType>,
         now: DateTime<Utc>,
@@ -205,7 +205,7 @@ impl Flag {
     fn eval<V: EvalAssignmentVisitor>(
         &self,
         visitor: &mut V,
-        subject_key: &ArcStr,
+        subject_key: &Str,
         subject_attributes: &Arc<Attributes>,
         now: DateTime<Utc>,
     ) -> Result<Assignment, EvaluationFailure> {
@@ -320,7 +320,7 @@ mod tests {
             get_assignment, get_assignment_details,
         },
         ufc::{RuleWire, UniversalFlagConfig, ValueWire, VariationType},
-        ArcStr, Attributes, Configuration, SdkMetadata,
+        Attributes, Configuration, SdkMetadata, Str,
     };
 
     #[derive(Debug, Serialize, Deserialize)]
@@ -342,7 +342,7 @@ mod tests {
     #[derive(Debug, Serialize, Deserialize)]
     #[serde(rename_all = "camelCase")]
     struct TestSubject {
-        subject_key: ArcStr,
+        subject_key: Str,
         subject_attributes: Arc<Attributes>,
         assignment: DefaultValue,
         evaluation_details: TruncatedEvaluationDetails,
@@ -352,13 +352,13 @@ mod tests {
     #[serde(rename_all = "camelCase")]
     struct TruncatedEvaluationDetails {
         /// Environment the configuration belongs to. None if configuration hasn't been fetched yet.
-        environment_name: Option<ArcStr>,
+        environment_name: Option<Str>,
 
         flag_evaluation_code: TruncatedFlagEvaluationCode,
         flag_evaluation_description: String,
 
         /// Key of the selected variation.
-        variation_key: Option<ArcStr>,
+        variation_key: Option<Str>,
         /// Value of the selected variation. Could be `None` if no variation is selected, or selected
         /// value is absent in configuration (configuration error).
         variation_value: serde_json::Value,
@@ -394,7 +394,7 @@ mod tests {
     #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
     #[serde(rename_all = "camelCase")]
     pub struct TruncatedAllocationEvaluationDetails {
-        pub key: ArcStr,
+        pub key: Str,
         /// Order position of the allocation as seen in the Web UI.
         pub order_position: usize,
         pub allocation_evaluation_code: AllocationEvaluationCode,

--- a/eppo_core/src/eval/eval_assignment.rs
+++ b/eppo_core/src/eval/eval_assignment.rs
@@ -297,11 +297,7 @@ impl Split {
 impl Shard {
     /// Return `true` if `subject_key` matches the given shard.
     fn matches<V: EvalSplitVisitor>(&self, visitor: &mut V, subject_key: &str) -> bool {
-        let mut md5_context = self.md5_context.clone();
-        md5_context.consume(subject_key);
-        let hash = md5_context.compute();
-        let value = u32::from_be_bytes(hash[0..4].try_into().unwrap());
-        let h = value % self.total_shards;
+        let h = self.sharder.shard(&[subject_key]);
 
         let matches = self.ranges.iter().any(|range| range.contains(h));
         visitor.on_shard_eval(self, h, matches);

--- a/eppo_core/src/eval/eval_assignment.rs
+++ b/eppo_core/src/eval/eval_assignment.rs
@@ -425,7 +425,7 @@ mod tests {
         match value {
             DefaultValue::Value(v) => v,
             DefaultValue::Json(json) => {
-                ValueWire::String(serde_json::to_string(&json).unwrap().as_str().into())
+                ValueWire::String(serde_json::to_string(&json).unwrap().into())
             }
         }
     }

--- a/eppo_core/src/eval/eval_assignment.rs
+++ b/eppo_core/src/eval/eval_assignment.rs
@@ -285,12 +285,9 @@ impl Split {
     ///
     /// To match a split, subject must match all underlying shards.
     fn matches<V: EvalSplitVisitor>(&self, visitor: &mut V, subject_key: &str) -> bool {
-        match &self.shards {
-            None => true,
-            Some(shards) => shards
-                .iter()
-                .all(|shard| shard.matches(visitor, subject_key)),
-        }
+        self.shards
+            .iter()
+            .all(|shard| shard.matches(visitor, subject_key))
     }
 }
 

--- a/eppo_core/src/eval/eval_bandits.rs
+++ b/eppo_core/src/eval/eval_bandits.rs
@@ -11,7 +11,7 @@ use crate::error::EvaluationFailure;
 use crate::events::{AssignmentEvent, BanditEvent};
 use crate::sharder::get_md5_shard;
 use crate::ufc::{Assignment, AssignmentValue, VariationType};
-use crate::{ArcStr, Configuration, EvaluationError};
+use crate::{Configuration, EvaluationError, Str};
 use crate::{ContextAttributes, SdkMetadata};
 
 use super::eval_assignment::get_assignment_with_visitor;
@@ -37,7 +37,7 @@ struct Action<'a> {
 #[derive(Debug, Clone, Serialize)]
 pub struct BanditResult {
     /// Selected variation from the feature flag.
-    pub variation: ArcStr,
+    pub variation: Str,
     /// Selected action if any.
     pub action: Option<String>,
     /// Flag assignment event that needs to be logged to analytics storage.
@@ -51,10 +51,10 @@ pub struct BanditResult {
 pub fn get_bandit_action(
     configuration: Option<&Configuration>,
     flag_key: &str,
-    subject_key: &ArcStr,
+    subject_key: &Str,
     subject_attributes: &ContextAttributes,
     actions: &HashMap<String, ContextAttributes>,
-    default_variation: &ArcStr,
+    default_variation: &Str,
     now: DateTime<Utc>,
     sdk_meta: &SdkMetadata,
 ) -> BanditResult {
@@ -76,10 +76,10 @@ pub fn get_bandit_action(
 pub fn get_bandit_action_details(
     configuration: Option<&Configuration>,
     flag_key: &str,
-    subject_key: &ArcStr,
+    subject_key: &Str,
     subject_attributes: &ContextAttributes,
     actions: &HashMap<String, ContextAttributes>,
-    default_variation: &ArcStr,
+    default_variation: &Str,
     now: DateTime<Utc>,
     sdk_meta: &SdkMetadata,
 ) -> (BanditResult, EvaluationDetails) {
@@ -110,10 +110,10 @@ fn get_bandit_action_with_visitor<V: EvalBanditVisitor>(
     visitor: &mut V,
     configuration: Option<&Configuration>,
     flag_key: &str,
-    subject_key: &ArcStr,
+    subject_key: &Str,
     subject_attributes: &ContextAttributes,
     actions: &HashMap<String, ContextAttributes>,
-    default_variation: &ArcStr,
+    default_variation: &Str,
     now: DateTime<Utc>,
     sdk_meta: &SdkMetadata,
 ) -> BanditResult {
@@ -410,22 +410,22 @@ mod tests {
     use serde::{Deserialize, Serialize};
 
     use crate::{
-        eval::get_bandit_action, ufc::UniversalFlagConfig, ArcStr, Configuration,
-        ContextAttributes, SdkMetadata,
+        eval::get_bandit_action, ufc::UniversalFlagConfig, Configuration, ContextAttributes,
+        SdkMetadata, Str,
     };
 
     #[derive(Debug, Serialize, Deserialize)]
     #[serde(rename_all = "camelCase")]
     struct TestFile {
         flag: String,
-        default_value: ArcStr,
+        default_value: Str,
         subjects: Vec<TestSubject>,
     }
 
     #[derive(Debug, Serialize, Deserialize)]
     #[serde(rename_all = "camelCase")]
     struct TestSubject {
-        subject_key: ArcStr,
+        subject_key: Str,
         subject_attributes: TestContextAttributes,
         actions: Vec<TestAction>,
         assignment: TestAssignment,
@@ -435,7 +435,7 @@ mod tests {
     #[serde(rename_all = "camelCase")]
     struct TestContextAttributes {
         numeric_attributes: HashMap<String, f64>,
-        categorical_attributes: HashMap<String, ArcStr>,
+        categorical_attributes: HashMap<String, Str>,
     }
     impl From<TestContextAttributes> for ContextAttributes {
         fn from(value: TestContextAttributes) -> ContextAttributes {
@@ -457,7 +457,7 @@ mod tests {
     #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
     #[serde(rename_all = "camelCase")]
     struct TestAssignment {
-        variation: ArcStr,
+        variation: Str,
         action: Option<String>,
     }
 

--- a/eppo_core/src/eval/eval_bandits.rs
+++ b/eppo_core/src/eval/eval_bandits.rs
@@ -392,7 +392,7 @@ fn score_attributes(
             attributes
                 .categorical
                 .get(&coef.attribute_key)
-                .and_then(|value| coef.value_coefficients.get(value))
+                .and_then(|value| coef.value_coefficients.get(value.as_str()))
                 .copied()
                 .unwrap_or(coef.missing_value_coefficient)
         }))
@@ -435,7 +435,7 @@ mod tests {
     #[serde(rename_all = "camelCase")]
     struct TestContextAttributes {
         numeric_attributes: HashMap<String, f64>,
-        categorical_attributes: HashMap<String, String>,
+        categorical_attributes: HashMap<String, ArcStr>,
     }
     impl From<TestContextAttributes> for ContextAttributes {
         fn from(value: TestContextAttributes) -> ContextAttributes {

--- a/eppo_core/src/eval/eval_bandits.rs
+++ b/eppo_core/src/eval/eval_bandits.rs
@@ -37,7 +37,7 @@ struct Action<'a> {
 #[derive(Debug, Clone, Serialize)]
 pub struct BanditResult {
     /// Selected variation from the feature flag.
-    pub variation: String,
+    pub variation: ArcStr,
     /// Selected action if any.
     pub action: Option<String>,
     /// Flag assignment event that needs to be logged to analytics storage.
@@ -54,7 +54,7 @@ pub fn get_bandit_action(
     subject_key: &ArcStr,
     subject_attributes: &ContextAttributes,
     actions: &HashMap<String, ContextAttributes>,
-    default_variation: &str,
+    default_variation: &ArcStr,
     now: DateTime<Utc>,
     sdk_meta: &SdkMetadata,
 ) -> BanditResult {
@@ -79,7 +79,7 @@ pub fn get_bandit_action_details(
     subject_key: &ArcStr,
     subject_attributes: &ContextAttributes,
     actions: &HashMap<String, ContextAttributes>,
-    default_variation: &str,
+    default_variation: &ArcStr,
     now: DateTime<Utc>,
     sdk_meta: &SdkMetadata,
 ) -> (BanditResult, EvaluationDetails) {
@@ -113,13 +113,13 @@ fn get_bandit_action_with_visitor<V: EvalBanditVisitor>(
     subject_key: &ArcStr,
     subject_attributes: &ContextAttributes,
     actions: &HashMap<String, ContextAttributes>,
-    default_variation: &str,
+    default_variation: &ArcStr,
     now: DateTime<Utc>,
     sdk_meta: &SdkMetadata,
 ) -> BanditResult {
     let Some(configuration) = configuration else {
         let result = BanditResult {
-            variation: default_variation.to_owned(),
+            variation: default_variation.clone(),
             action: None,
             assignment_event: None,
             bandit_event: None,
@@ -141,7 +141,7 @@ fn get_bandit_action_with_visitor<V: EvalBanditVisitor>(
     )
     .unwrap_or_default()
     .unwrap_or_else(|| Assignment {
-        value: AssignmentValue::String(default_variation.to_owned()),
+        value: AssignmentValue::String(default_variation.clone()),
         event: None,
     });
 
@@ -418,7 +418,7 @@ mod tests {
     #[serde(rename_all = "camelCase")]
     struct TestFile {
         flag: String,
-        default_value: String,
+        default_value: ArcStr,
         subjects: Vec<TestSubject>,
     }
 
@@ -457,7 +457,7 @@ mod tests {
     #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
     #[serde(rename_all = "camelCase")]
     struct TestAssignment {
-        variation: String,
+        variation: ArcStr,
         action: Option<String>,
     }
 

--- a/eppo_core/src/eval/eval_bandits.rs
+++ b/eppo_core/src/eval/eval_bandits.rs
@@ -138,7 +138,6 @@ fn get_bandit_action_with_visitor<V: EvalBanditVisitor>(
         &Arc::new(subject_attributes.to_generic_attributes()),
         Some(VariationType::String),
         now,
-        sdk_meta,
     )
     .unwrap_or_default()
     .unwrap_or_else(|| Assignment {
@@ -245,7 +244,7 @@ impl BanditModelData {
         actions: &HashMap<String, ContextAttributes>,
     ) -> Result<BanditEvaluationDetails, EvaluationFailure> {
         // total_shards is not configurable at the moment.
-        const TOTAL_SHARDS: u64 = 10_000;
+        const TOTAL_SHARDS: u32 = 10_000;
 
         if actions.len() == 0 {
             return Err(EvaluationFailure::NoActionsSuppliedForBandit);
@@ -410,7 +409,10 @@ mod tests {
     use chrono::Utc;
     use serde::{Deserialize, Serialize};
 
-    use crate::{eval::get_bandit_action, ArcStr, Configuration, ContextAttributes, SdkMetadata};
+    use crate::{
+        eval::get_bandit_action, ufc::UniversalFlagConfig, ArcStr, Configuration,
+        ContextAttributes, SdkMetadata,
+    };
 
     #[derive(Debug, Serialize, Deserialize)]
     #[serde(rename_all = "camelCase")]
@@ -461,8 +463,12 @@ mod tests {
 
     #[test]
     fn sdk_test_data() {
-        let config = serde_json::from_reader(
-            File::open("../sdk-test-data/ufc/bandit-flags-v1.json").unwrap(),
+        let config = UniversalFlagConfig::from_json(
+            SdkMetadata {
+                name: "test",
+                version: "0.1.0",
+            },
+            std::fs::read("../sdk-test-data/ufc/bandit-flags-v1.json").unwrap(),
         )
         .unwrap();
         let bandits = serde_json::from_reader(

--- a/eppo_core/src/eval/eval_details.rs
+++ b/eppo_core/src/eval/eval_details.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
@@ -66,8 +68,8 @@ impl<T> EvaluationResultWithDetails<T> {
 #[serde(rename_all = "camelCase")]
 pub struct EvaluationDetails {
     pub flag_key: String,
-    pub subject_key: String,
-    pub subject_attributes: Attributes,
+    pub subject_key: ArcStr,
+    pub subject_attributes: Arc<Attributes>,
     /// Timestamp when the flag was evaluated.
     pub timestamp: DateTime<Utc>,
 

--- a/eppo_core/src/eval/eval_details.rs
+++ b/eppo_core/src/eval/eval_details.rs
@@ -49,7 +49,7 @@ pub enum BanditEvaluationCode {
 pub struct EvaluationResultWithDetails<T> {
     pub variation: Option<T>,
     pub action: Option<String>,
-    pub evaluation_details: EvaluationDetails,
+    pub evaluation_details: Arc<EvaluationDetails>,
 }
 
 impl<T> EvaluationResultWithDetails<T> {
@@ -110,7 +110,7 @@ pub struct AllocationEvaluationDetails {
     pub evaluated_splits: Vec<SplitEvaluationDetails>,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum AllocationEvaluationCode {
     /// The allocation was not evaluated because previous allocation matched.

--- a/eppo_core/src/eval/eval_details.rs
+++ b/eppo_core/src/eval/eval_details.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     error::{EvaluationError, EvaluationFailure},
     ufc::{AssignmentValue, ConditionWire, Shard},
-    ArcStr, AttributeValue, Attributes,
+    AttributeValue, Attributes, Str,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
@@ -68,7 +68,7 @@ impl<T> EvaluationResultWithDetails<T> {
 #[serde(rename_all = "camelCase")]
 pub struct EvaluationDetails {
     pub flag_key: String,
-    pub subject_key: ArcStr,
+    pub subject_key: Str,
     pub subject_attributes: Arc<Attributes>,
     /// Timestamp when the flag was evaluated.
     pub timestamp: DateTime<Utc>,
@@ -80,14 +80,14 @@ pub struct EvaluationDetails {
     /// fetched yet.
     pub config_published_at: Option<DateTime<Utc>>,
     /// Environment the configuration belongs to. None if configuration hasn't been fetched yet.
-    pub environment_name: Option<ArcStr>,
+    pub environment_name: Option<Str>,
 
     pub bandit_evaluation_code: Option<BanditEvaluationCode>,
     pub flag_evaluation_code: Option<FlagEvaluationCode>,
     pub flag_evaluation_description: String,
 
     /// Key of the selected variation.
-    pub variation_key: Option<ArcStr>,
+    pub variation_key: Option<Str>,
     /// Value of the selected variation. Could be `None` if no variation is selected, or selected
     /// value is absent in configuration (configuration error).
     pub variation_value: Option<AssignmentValue>,
@@ -102,7 +102,7 @@ pub struct EvaluationDetails {
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AllocationEvaluationDetails {
-    pub key: ArcStr,
+    pub key: Str,
     /// Order position of the allocation as seen in the Web UI.
     pub order_position: usize,
     pub allocation_evaluation_code: AllocationEvaluationCode,
@@ -145,7 +145,7 @@ pub struct ConditionEvaluationDetails {
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SplitEvaluationDetails {
-    pub variation_key: ArcStr,
+    pub variation_key: Str,
     pub matched: bool,
     pub shards: Vec<ShardEvaluationDetails>,
 }

--- a/eppo_core/src/eval/eval_details.rs
+++ b/eppo_core/src/eval/eval_details.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     error::{EvaluationError, EvaluationFailure},
-    ufc::{ConditionWire, Shard, Value},
+    ufc::{AssignmentValue, ConditionWire, Shard},
     ArcStr, AttributeValue, Attributes,
 };
 
@@ -44,7 +44,7 @@ pub enum BanditEvaluationCode {
     NoActionsSuppliedForBandit,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct EvaluationResultWithDetails<T> {
     pub variation: Option<T>,
@@ -64,7 +64,7 @@ impl<T> EvaluationResultWithDetails<T> {
 }
 
 /// Details about feature flag or bandit evaluation.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct EvaluationDetails {
     pub flag_key: String,
@@ -87,10 +87,10 @@ pub struct EvaluationDetails {
     pub flag_evaluation_description: String,
 
     /// Key of the selected variation.
-    pub variation_key: Option<String>,
+    pub variation_key: Option<ArcStr>,
     /// Value of the selected variation. Could be `None` if no variation is selected, or selected
     /// value is absent in configuration (configuration error).
-    pub variation_value: Option<Value>,
+    pub variation_value: Option<AssignmentValue>,
 
     pub bandit_key: Option<String>,
     pub bandit_action: Option<String>,
@@ -99,7 +99,7 @@ pub struct EvaluationDetails {
     pub allocations: Vec<AllocationEvaluationDetails>,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AllocationEvaluationDetails {
     pub key: ArcStr,
@@ -127,35 +127,35 @@ pub enum AllocationEvaluationCode {
     TrafficExposureMiss,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RuleEvaluationDetails {
     pub matched: bool,
     pub conditions: Vec<ConditionEvaluationDetails>,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ConditionEvaluationDetails {
-    pub condition: ConditionWire,
+    pub(crate) condition: ConditionWire,
     pub attribute_value: Option<AttributeValue>,
     pub matched: bool,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SplitEvaluationDetails {
-    pub variation_key: String,
+    pub variation_key: ArcStr,
     pub matched: bool,
     pub shards: Vec<ShardEvaluationDetails>,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ShardEvaluationDetails {
     pub matched: bool,
     pub shard: Shard,
-    pub shard_value: u64,
+    pub shard_value: u32,
 }
 
 impl From<Result<(), EvaluationFailure>> for FlagEvaluationCode {

--- a/eppo_core/src/eval/eval_details.rs
+++ b/eppo_core/src/eval/eval_details.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     error::{EvaluationError, EvaluationFailure},
     ufc::{ConditionWire, Shard, Value},
-    AttributeValue, Attributes,
+    ArcStr, AttributeValue, Attributes,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
@@ -78,7 +78,7 @@ pub struct EvaluationDetails {
     /// fetched yet.
     pub config_published_at: Option<DateTime<Utc>>,
     /// Environment the configuration belongs to. None if configuration hasn't been fetched yet.
-    pub environment_name: Option<String>,
+    pub environment_name: Option<ArcStr>,
 
     pub bandit_evaluation_code: Option<BanditEvaluationCode>,
     pub flag_evaluation_code: Option<FlagEvaluationCode>,
@@ -100,7 +100,7 @@ pub struct EvaluationDetails {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AllocationEvaluationDetails {
-    pub key: String,
+    pub key: ArcStr,
     /// Order position of the allocation as seen in the Web UI.
     pub order_position: usize,
     pub allocation_evaluation_code: AllocationEvaluationCode,

--- a/eppo_core/src/eval/eval_details_builder.rs
+++ b/eppo_core/src/eval/eval_details_builder.rs
@@ -348,7 +348,7 @@ impl<'b> EvalAllocationVisitor for EvalAllocationDetailsBuilder<'b> {
             *self.matched = Some(MatchedDetails {
                 has_rules: self.allocation_has_rules,
                 is_experiment: self.allocation_is_experiment,
-                is_partial_rollout: split.shards.as_ref().is_some_and(|it| it.len() > 1),
+                is_partial_rollout: split.shards.len() > 1,
             })
         }
 

--- a/eppo_core/src/eval/eval_details_builder.rs
+++ b/eppo_core/src/eval/eval_details_builder.rs
@@ -4,10 +4,7 @@ use chrono::{DateTime, Utc};
 
 use crate::{
     error::EvaluationFailure,
-    ufc::{
-        Allocation, Assignment, Condition, ConditionWire, Flag, Rule, Shard, Split, Value,
-        Variation,
-    },
+    ufc::{Allocation, Assignment, AssignmentValue, Condition, Flag, RuleWire, Shard, Split},
     ArcStr, AttributeValue, Attributes, Configuration, EvaluationError,
 };
 
@@ -30,8 +27,8 @@ pub(crate) struct EvalDetailsBuilder {
     environment_name: Option<ArcStr>,
 
     flag_evaluation_failure: Option<Result<(), EvaluationFailure>>,
-    variation_key: Option<String>,
-    variation_value: Option<Value>,
+    variation_key: Option<ArcStr>,
+    variation_value: Option<AssignmentValue>,
 
     bandit_evaluation_failure: Option<Result<(), EvaluationFailure>>,
     bandit_key: Option<String>,
@@ -57,7 +54,7 @@ pub(crate) struct EvalAllocationDetailsBuilder<'a> {
     allocation_is_experiment: bool,
     matched: &'a mut Option<MatchedDetails>,
     allocation_details: &'a mut AllocationEvaluationDetails,
-    variation_key: &'a mut Option<String>,
+    variation_key: &'a mut Option<ArcStr>,
 }
 
 pub(crate) struct EvalRuleDetailsBuilder<'a> {
@@ -249,10 +246,6 @@ impl<'b> EvalAssignmentVisitor for &'b mut EvalDetailsBuilder {
         EvalAssignmentVisitor::on_flag_configuration(*self, flag)
     }
 
-    fn on_variation(&mut self, variation: &Variation) {
-        EvalAssignmentVisitor::on_variation(*self, variation)
-    }
-
     fn on_result(&mut self, result: &Result<Assignment, EvaluationFailure>) {
         EvalAssignmentVisitor::on_result(*self, result)
     }
@@ -287,8 +280,8 @@ impl EvalAssignmentVisitor for EvalDetailsBuilder {
 
     fn on_configuration(&mut self, configuration: &Configuration) {
         self.configuration_fetched_at = Some(configuration.fetched_at);
-        self.configuration_published_at = Some(configuration.flags.created_at);
-        self.environment_name = Some(configuration.flags.environment.name.clone());
+        self.configuration_published_at = Some(configuration.flags.compiled.created_at);
+        self.environment_name = Some(configuration.flags.compiled.environment.name.clone());
     }
 
     fn on_flag_configuration(&mut self, flag: &Flag) {
@@ -297,15 +290,14 @@ impl EvalAssignmentVisitor for EvalDetailsBuilder {
             .extend(flag.allocations.iter().map(|it| &it.key).cloned());
     }
 
-    fn on_variation(&mut self, variation: &Variation) {
-        self.variation_value = Some(variation.value.clone());
-    }
-
     fn on_result(&mut self, result: &Result<Assignment, EvaluationFailure>) {
-        self.flag_evaluation_failure = Some(match result {
-            Ok(_) => Ok(()),
-            Err(failure) => Err(*failure),
-        });
+        match result {
+            Ok(assignment) => {
+                self.variation_value = Some(assignment.value.clone());
+                self.flag_evaluation_failure = Some(Ok(()));
+            }
+            Err(failure) => self.flag_evaluation_failure = Some(Err(*failure)),
+        };
     }
 }
 
@@ -318,7 +310,7 @@ impl<'b> EvalAllocationVisitor for EvalAllocationDetailsBuilder<'b> {
     where
         Self: 'a;
 
-    fn visit_rule<'a>(&'a mut self, _rule: &Rule) -> EvalRuleDetailsBuilder<'a> {
+    fn visit_rule<'a>(&'a mut self, _rule: &RuleWire) -> EvalRuleDetailsBuilder<'a> {
         self.allocation_details
             .evaluated_rules
             .push(RuleEvaluationDetails {
@@ -356,7 +348,7 @@ impl<'b> EvalAllocationVisitor for EvalAllocationDetailsBuilder<'b> {
             *self.matched = Some(MatchedDetails {
                 has_rules: self.allocation_has_rules,
                 is_experiment: self.allocation_is_experiment,
-                is_partial_rollout: split.shards.len() > 1,
+                is_partial_rollout: split.shards.as_ref().is_some_and(|it| it.len() > 1),
             })
         }
 
@@ -392,30 +384,13 @@ impl<'a> EvalRuleVisitor for EvalRuleDetailsBuilder<'a> {
             });
     }
 
-    fn on_condition_skip(&mut self, condition: &serde_json::Value) {
-        let condition = match serde_json::from_value::<ConditionWire>(condition.clone()) {
-            Ok(condition_wire) => condition_wire,
-            Err(err) => {
-                log::warn!("condition cannot be parsed: {err:?}");
-                return;
-            }
-        };
-        self.rule_details
-            .conditions
-            .push(ConditionEvaluationDetails {
-                condition,
-                attribute_value: None,
-                matched: false,
-            });
-    }
-
     fn on_result(&mut self, result: bool) {
         self.rule_details.matched = result;
     }
 }
 
 impl<'a> EvalSplitVisitor for EvalSplitDetailsBuilder<'a> {
-    fn on_shard_eval(&mut self, shard: &Shard, shard_value: u64, matches: bool) {
+    fn on_shard_eval(&mut self, shard: &Shard, shard_value: u32, matches: bool) {
         self.split_details.shards.push(ShardEvaluationDetails {
             matched: matches,
             shard: shard.clone(),

--- a/eppo_core/src/eval/eval_details_builder.rs
+++ b/eppo_core/src/eval/eval_details_builder.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::Arc};
 
 use chrono::{DateTime, Utc};
 
@@ -21,8 +21,8 @@ use super::{
 /// It works with both assignment and bandit evaluation.
 pub(crate) struct EvalDetailsBuilder {
     flag_key: String,
-    subject_key: String,
-    subject_attributes: Attributes,
+    subject_key: ArcStr,
+    subject_attributes: Arc<Attributes>,
     now: DateTime<Utc>,
 
     configuration_fetched_at: Option<DateTime<Utc>>,
@@ -71,8 +71,8 @@ pub(crate) struct EvalSplitDetailsBuilder<'a> {
 impl EvalDetailsBuilder {
     pub fn new(
         flag_key: String,
-        subject_key: String,
-        subject_attributes: Attributes,
+        subject_key: ArcStr,
+        subject_attributes: Arc<Attributes>,
         now: DateTime<Utc>,
     ) -> EvalDetailsBuilder {
         EvalDetailsBuilder {

--- a/eppo_core/src/eval/eval_details_builder.rs
+++ b/eppo_core/src/eval/eval_details_builder.rs
@@ -5,7 +5,7 @@ use chrono::{DateTime, Utc};
 use crate::{
     error::EvaluationFailure,
     ufc::{Allocation, Assignment, AssignmentValue, Condition, Flag, RuleWire, Shard, Split},
-    ArcStr, AttributeValue, Attributes, Configuration, EvaluationError,
+    AttributeValue, Attributes, Configuration, EvaluationError, Str,
 };
 
 use super::{
@@ -18,16 +18,16 @@ use super::{
 /// It works with both assignment and bandit evaluation.
 pub(crate) struct EvalDetailsBuilder {
     flag_key: String,
-    subject_key: ArcStr,
+    subject_key: Str,
     subject_attributes: Arc<Attributes>,
     now: DateTime<Utc>,
 
     configuration_fetched_at: Option<DateTime<Utc>>,
     configuration_published_at: Option<DateTime<Utc>>,
-    environment_name: Option<ArcStr>,
+    environment_name: Option<Str>,
 
     flag_evaluation_failure: Option<Result<(), EvaluationFailure>>,
-    variation_key: Option<ArcStr>,
+    variation_key: Option<Str>,
     variation_value: Option<AssignmentValue>,
 
     bandit_evaluation_failure: Option<Result<(), EvaluationFailure>>,
@@ -38,8 +38,8 @@ pub(crate) struct EvalDetailsBuilder {
     matched_details: Option<MatchedDetails>,
 
     /// List of allocation keys. Used to sort `allocation_eval_results`.
-    allocation_keys_order: Vec<ArcStr>,
-    allocation_eval_results: HashMap<ArcStr, AllocationEvaluationDetails>,
+    allocation_keys_order: Vec<Str>,
+    allocation_eval_results: HashMap<Str, AllocationEvaluationDetails>,
 }
 
 /// Interim struct to construct `flag_evaluation_details` later.
@@ -54,7 +54,7 @@ pub(crate) struct EvalAllocationDetailsBuilder<'a> {
     allocation_is_experiment: bool,
     matched: &'a mut Option<MatchedDetails>,
     allocation_details: &'a mut AllocationEvaluationDetails,
-    variation_key: &'a mut Option<ArcStr>,
+    variation_key: &'a mut Option<Str>,
 }
 
 pub(crate) struct EvalRuleDetailsBuilder<'a> {
@@ -68,7 +68,7 @@ pub(crate) struct EvalSplitDetailsBuilder<'a> {
 impl EvalDetailsBuilder {
     pub fn new(
         flag_key: String,
-        subject_key: ArcStr,
+        subject_key: Str,
         subject_attributes: Arc<Attributes>,
         now: DateTime<Utc>,
     ) -> EvalDetailsBuilder {

--- a/eppo_core/src/eval/evaluator.rs
+++ b/eppo_core/src/eval/evaluator.rs
@@ -46,7 +46,6 @@ impl Evaluator {
             &subject_attributes,
             expected_type,
             Utc::now(),
-            &self.config.sdk_metadata,
         )
     }
 
@@ -68,7 +67,6 @@ impl Evaluator {
             &subject_attributes,
             expected_type,
             Utc::now(),
-            &self.config.sdk_metadata,
         )
     }
 

--- a/eppo_core/src/eval/evaluator.rs
+++ b/eppo_core/src/eval/evaluator.rs
@@ -6,7 +6,7 @@ use crate::{
     configuration_store::ConfigurationStore,
     events::AssignmentEvent,
     ufc::{Assignment, AssignmentValue, VariationType},
-    ArcStr, Attributes, Configuration, ContextAttributes, EvaluationError, SdkMetadata,
+    Attributes, Configuration, ContextAttributes, EvaluationError, SdkMetadata, Str,
 };
 
 use super::{
@@ -34,7 +34,7 @@ impl Evaluator {
     pub fn get_assignment(
         &self,
         flag_key: &str,
-        subject_key: &ArcStr,
+        subject_key: &Str,
         subject_attributes: &Arc<Attributes>,
         expected_type: Option<VariationType>,
     ) -> Result<Option<Assignment>, EvaluationError> {
@@ -52,7 +52,7 @@ impl Evaluator {
     pub fn get_assignment_details(
         &self,
         flag_key: &str,
-        subject_key: &ArcStr,
+        subject_key: &Str,
         subject_attributes: &Arc<Attributes>,
         expected_type: Option<VariationType>,
     ) -> (
@@ -73,10 +73,10 @@ impl Evaluator {
     pub fn get_bandit_action(
         &self,
         flag_key: &str,
-        subject_key: &ArcStr,
+        subject_key: &Str,
         subject_attributes: &ContextAttributes,
         actions: &HashMap<String, ContextAttributes>,
-        default_variation: &ArcStr,
+        default_variation: &Str,
     ) -> BanditResult {
         let configuration = self.get_configuration();
         get_bandit_action(
@@ -94,10 +94,10 @@ impl Evaluator {
     pub fn get_bandit_action_details(
         &self,
         flag_key: &str,
-        subject_key: &ArcStr,
+        subject_key: &Str,
         subject_attributes: &ContextAttributes,
         actions: &HashMap<String, ContextAttributes>,
-        default_variation: &ArcStr,
+        default_variation: &Str,
     ) -> (BanditResult, EvaluationDetails) {
         let configuration = self.get_configuration();
         get_bandit_action_details(

--- a/eppo_core/src/eval/evaluator.rs
+++ b/eppo_core/src/eval/evaluator.rs
@@ -6,7 +6,7 @@ use crate::{
     configuration_store::ConfigurationStore,
     events::AssignmentEvent,
     ufc::{Assignment, AssignmentValue, VariationType},
-    Attributes, Configuration, ContextAttributes, EvaluationError, SdkMetadata,
+    ArcStr, Attributes, Configuration, ContextAttributes, EvaluationError, SdkMetadata,
 };
 
 use super::{
@@ -34,8 +34,8 @@ impl Evaluator {
     pub fn get_assignment(
         &self,
         flag_key: &str,
-        subject_key: &str,
-        subject_attributes: &Attributes,
+        subject_key: &ArcStr,
+        subject_attributes: &Arc<Attributes>,
         expected_type: Option<VariationType>,
     ) -> Result<Option<Assignment>, EvaluationError> {
         let config = self.get_configuration();
@@ -53,8 +53,8 @@ impl Evaluator {
     pub fn get_assignment_details(
         &self,
         flag_key: &str,
-        subject_key: &str,
-        subject_attributes: &Attributes,
+        subject_key: &ArcStr,
+        subject_attributes: &Arc<Attributes>,
         expected_type: Option<VariationType>,
     ) -> (
         EvaluationResultWithDetails<AssignmentValue>,
@@ -75,7 +75,7 @@ impl Evaluator {
     pub fn get_bandit_action(
         &self,
         flag_key: &str,
-        subject_key: &str,
+        subject_key: &ArcStr,
         subject_attributes: &ContextAttributes,
         actions: &HashMap<String, ContextAttributes>,
         default_variation: &str,
@@ -96,7 +96,7 @@ impl Evaluator {
     pub fn get_bandit_action_details(
         &self,
         flag_key: &str,
-        subject_key: &str,
+        subject_key: &ArcStr,
         subject_attributes: &ContextAttributes,
         actions: &HashMap<String, ContextAttributes>,
         default_variation: &str,

--- a/eppo_core/src/eval/evaluator.rs
+++ b/eppo_core/src/eval/evaluator.rs
@@ -76,7 +76,7 @@ impl Evaluator {
         subject_key: &ArcStr,
         subject_attributes: &ContextAttributes,
         actions: &HashMap<String, ContextAttributes>,
-        default_variation: &str,
+        default_variation: &ArcStr,
     ) -> BanditResult {
         let configuration = self.get_configuration();
         get_bandit_action(
@@ -97,7 +97,7 @@ impl Evaluator {
         subject_key: &ArcStr,
         subject_attributes: &ContextAttributes,
         actions: &HashMap<String, ContextAttributes>,
-        default_variation: &str,
+        default_variation: &ArcStr,
     ) -> (BanditResult, EvaluationDetails) {
         let configuration = self.get_configuration();
         get_bandit_action_details(

--- a/eppo_core/src/events.rs
+++ b/eppo_core/src/events.rs
@@ -41,7 +41,7 @@ pub struct AssignmentEvent {
     /// Evaluation details that could help with debugging the assigment. Only populated when
     /// details-version of the `get_assigment` was called.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub evaluation_details: Option<EvaluationDetails>,
+    pub evaluation_details: Option<Arc<EvaluationDetails>>,
 }
 
 /// Bandit evaluation event that needs to be logged to analytics storage.

--- a/eppo_core/src/events.rs
+++ b/eppo_core/src/events.rs
@@ -1,8 +1,8 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::Arc};
 
 use serde::{Deserialize, Serialize};
 
-use crate::{eval::eval_details::EvaluationDetails, Attributes};
+use crate::{eval::eval_details::EvaluationDetails, ArcStr, Attributes};
 
 /// Events that can be emitted during evaluation of assignment or bandit. They need to be logged to
 /// analytics storage and fed back to Eppo for analysis.
@@ -19,25 +19,25 @@ pub struct Events {
 #[serde(rename_all = "camelCase")]
 pub struct AssignmentEvent {
     /// The key of the feature flag being assigned.
-    pub feature_flag: String,
+    pub feature_flag: ArcStr,
     /// The key of the allocation that the subject was assigned to.
-    pub allocation: String,
+    pub allocation: ArcStr,
     /// The key of the experiment associated with the assignment.
     pub experiment: String,
     /// The specific variation assigned to the subject.
-    pub variation: String,
+    pub variation: ArcStr,
     /// The key identifying the subject receiving the assignment.
     pub subject: String,
     /// Custom attributes of the subject relevant to the assignment.
     pub subject_attributes: Attributes,
     /// The timestamp indicating when the assignment event occurred.
-    pub timestamp: String,
+    pub timestamp: chrono::DateTime<chrono::Utc>,
     /// Additional metadata such as SDK language and version.
     pub meta_data: HashMap<String, String>,
     /// Additional user-defined logging fields for capturing extra information related to the
     /// assignment.
     #[serde(flatten)]
-    pub extra_logging: HashMap<String, String>,
+    pub extra_logging: Arc<HashMap<String, String>>,
     /// Evaluation details that could help with debugging the assigment. Only populated when
     /// details-version of the `get_assigment` was called.
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/eppo_core/src/events.rs
+++ b/eppo_core/src/events.rs
@@ -27,9 +27,9 @@ pub struct AssignmentEvent {
     /// The specific variation assigned to the subject.
     pub variation: ArcStr,
     /// The key identifying the subject receiving the assignment.
-    pub subject: String,
+    pub subject: ArcStr,
     /// Custom attributes of the subject relevant to the assignment.
-    pub subject_attributes: Attributes,
+    pub subject_attributes: Arc<Attributes>,
     /// The timestamp indicating when the assignment event occurred.
     pub timestamp: chrono::DateTime<chrono::Utc>,
     /// Additional metadata such as SDK language and version.
@@ -50,7 +50,7 @@ pub struct AssignmentEvent {
 pub struct BanditEvent {
     pub flag_key: String,
     pub bandit_key: String,
-    pub subject: String,
+    pub subject: ArcStr,
     pub action: String,
     pub action_probability: f64,
     pub optimality_gap: f64,

--- a/eppo_core/src/events.rs
+++ b/eppo_core/src/events.rs
@@ -2,7 +2,7 @@ use std::{collections::HashMap, sync::Arc};
 
 use serde::Serialize;
 
-use crate::{eval::eval_details::EvaluationDetails, ArcStr, Attributes, SdkMetadata};
+use crate::{eval::eval_details::EvaluationDetails, Attributes, SdkMetadata, Str};
 
 /// Events that can be emitted during evaluation of assignment or bandit. They need to be logged to
 /// analytics storage and fed back to Eppo for analysis.
@@ -18,13 +18,13 @@ pub struct Events {
 #[serde(rename_all = "camelCase")]
 pub struct AssignmentEventBase {
     /// The key of the feature flag being assigned.
-    pub feature_flag: ArcStr,
+    pub feature_flag: Str,
     /// The key of the allocation that the subject was assigned to.
-    pub allocation: ArcStr,
+    pub allocation: Str,
     /// The key of the experiment associated with the assignment.
     pub experiment: String,
     /// The specific variation assigned to the subject.
-    pub variation: ArcStr,
+    pub variation: Str,
     /// Additional metadata such as SDK language and version.
     pub meta_data: EventMetaData,
     /// Additional user-defined logging fields for capturing extra information related to the
@@ -40,7 +40,7 @@ pub struct AssignmentEventBase {
 pub struct AssignmentEvent {
     pub base: Arc<AssignmentEventBase>,
     /// The key identifying the subject receiving the assignment.
-    pub subject: ArcStr,
+    pub subject: Str,
     /// Custom attributes of the subject relevant to the assignment.
     pub subject_attributes: Arc<Attributes>,
     /// The timestamp indicating when the assignment event occurred.
@@ -57,16 +57,16 @@ pub struct AssignmentEvent {
 pub struct BanditEvent {
     pub flag_key: String,
     pub bandit_key: String,
-    pub subject: ArcStr,
+    pub subject: Str,
     pub action: String,
     pub action_probability: f64,
     pub optimality_gap: f64,
     pub model_version: String,
     pub timestamp: String,
     pub subject_numeric_attributes: HashMap<String, f64>,
-    pub subject_categorical_attributes: HashMap<String, ArcStr>,
+    pub subject_categorical_attributes: HashMap<String, Str>,
     pub action_numeric_attributes: HashMap<String, f64>,
-    pub action_categorical_attributes: HashMap<String, ArcStr>,
+    pub action_categorical_attributes: HashMap<String, Str>,
     pub meta_data: EventMetaData,
 }
 

--- a/eppo_core/src/events.rs
+++ b/eppo_core/src/events.rs
@@ -64,9 +64,9 @@ pub struct BanditEvent {
     pub model_version: String,
     pub timestamp: String,
     pub subject_numeric_attributes: HashMap<String, f64>,
-    pub subject_categorical_attributes: HashMap<String, String>,
+    pub subject_categorical_attributes: HashMap<String, ArcStr>,
     pub action_numeric_attributes: HashMap<String, f64>,
-    pub action_categorical_attributes: HashMap<String, String>,
+    pub action_categorical_attributes: HashMap<String, ArcStr>,
     pub meta_data: EventMetaData,
 }
 

--- a/eppo_core/src/lib.rs
+++ b/eppo_core/src/lib.rs
@@ -65,9 +65,11 @@ mod configuration;
 mod context_attributes;
 mod error;
 mod sdk_metadata;
+mod str;
 
 pub use attributes::{AttributeValue, Attributes};
 pub use configuration::Configuration;
 pub use context_attributes::ContextAttributes;
 pub use error::{Error, EvaluationError, Result};
 pub use sdk_metadata::SdkMetadata;
+pub use str::ArcStr;

--- a/eppo_core/src/lib.rs
+++ b/eppo_core/src/lib.rs
@@ -67,9 +67,9 @@ mod error;
 mod sdk_metadata;
 mod str;
 
+pub use crate::str::Str;
 pub use attributes::{AttributeValue, Attributes};
 pub use configuration::Configuration;
 pub use context_attributes::ContextAttributes;
 pub use error::{Error, EvaluationError, Result};
 pub use sdk_metadata::SdkMetadata;
-pub use str::Str;

--- a/eppo_core/src/lib.rs
+++ b/eppo_core/src/lib.rs
@@ -72,4 +72,4 @@ pub use configuration::Configuration;
 pub use context_attributes::ContextAttributes;
 pub use error::{Error, EvaluationError, Result};
 pub use sdk_metadata::SdkMetadata;
-pub use str::ArcStr;
+pub use str::Str;

--- a/eppo_core/src/sdk_metadata.rs
+++ b/eppo_core/src/sdk_metadata.rs
@@ -1,7 +1,7 @@
 /// SDK metadata that is used in a couple of places:
 /// - added to assignment and bandit events
 /// - sent in query when requesting config
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SdkMetadata {
     /// SDK name. (Usually, language name.)
     pub name: &'static str,

--- a/eppo_core/src/sharder.rs
+++ b/eppo_core/src/sharder.rs
@@ -5,7 +5,7 @@ use md5;
 ///
 /// This function accepts an array of inputs to allow the caller to avoid allocating memory when
 /// input is compound from multiple segments.
-pub fn get_md5_shard(input: &[impl AsRef<[u8]>], total_shards: u64) -> u64 {
+pub fn get_md5_shard(input: &[impl AsRef<[u8]>], total_shards: u32) -> u32 {
     let hash = {
         let mut hasher = md5::Context::new();
         for i in input {
@@ -14,5 +14,5 @@ pub fn get_md5_shard(input: &[impl AsRef<[u8]>], total_shards: u64) -> u64 {
         hasher.compute()
     };
     let value = u32::from_be_bytes(hash[0..4].try_into().unwrap());
-    (value as u64) % total_shards
+    value % total_shards
 }

--- a/eppo_core/src/sharder.rs
+++ b/eppo_core/src/sharder.rs
@@ -1,6 +1,42 @@
 //! Sharder implementation.
 use md5;
 
+/// A sharder that has part of its hash pre-computed with the given salt.
+#[derive(Clone)]
+pub struct PreSaltedSharder {
+    ctx: md5::Context,
+    total_shards: u32,
+}
+
+impl PreSaltedSharder {
+    pub fn new(salt: &[impl AsRef<[u8]>], total_shards: u32) -> PreSaltedSharder {
+        let mut ctx = md5::Context::new();
+        for s in salt {
+            ctx.consume(s);
+        }
+        PreSaltedSharder { ctx, total_shards }
+    }
+
+    pub fn shard(&self, input: &[impl AsRef<[u8]>]) -> u32 {
+        let mut ctx = self.ctx.clone();
+        for i in input {
+            ctx.consume(i);
+        }
+        let hash = ctx.compute();
+        let value = u32::from_be_bytes(hash[0..4].try_into().unwrap());
+        value % self.total_shards
+    }
+}
+
+impl std::fmt::Debug for PreSaltedSharder {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PreSaltedSharder")
+            .field("ctx", &"...")
+            .field("total_shards", &self.total_shards)
+            .finish()
+    }
+}
+
 /// Compute md5 shard for the set of inputs.
 ///
 /// This function accepts an array of inputs to allow the caller to avoid allocating memory when

--- a/eppo_core/src/str.rs
+++ b/eppo_core/src/str.rs
@@ -2,14 +2,36 @@
 //!
 //! Moved into a separate module, so we could experiment with different representations.
 
-use std::sync::Arc;
+use std::{borrow::Cow, sync::Arc};
+
+use faststr::FastStr;
 
 use serde::{Deserialize, Serialize};
 
 /// `ArcStr` is a string that can be cloned cheaply.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Deserialize, Serialize)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Deserialize, Serialize)]
 #[serde(transparent)]
-pub struct ArcStr(Arc<str>);
+pub struct ArcStr(FastStr);
+
+impl ArcStr {
+    pub fn new<S: AsRef<str>>(s: S) -> ArcStr {
+        ArcStr(FastStr::new(s))
+    }
+
+    pub fn from_static_str(s: &'static str) -> ArcStr {
+        ArcStr(FastStr::from_static_str(s))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::fmt::Debug for ArcStr {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self.0)
+    }
+}
 
 impl std::fmt::Display for ArcStr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -17,9 +39,33 @@ impl std::fmt::Display for ArcStr {
     }
 }
 
-impl<T: Into<Arc<str>>> From<T> for ArcStr {
-    fn from(value: T) -> ArcStr {
-        ArcStr(value.into())
+macro_rules! impl_from_faststr {
+    ($ty:ty) => {
+        impl From<$ty> for ArcStr {
+            fn from(value: $ty) -> ArcStr {
+                ArcStr(value.into())
+            }
+        }
+    };
+}
+
+impl_from_faststr!(Arc<str>);
+impl_from_faststr!(Arc<String>);
+impl_from_faststr!(String);
+impl_from_faststr!(FastStr);
+
+impl<'a> From<&'a str> for ArcStr {
+    fn from(value: &'a str) -> ArcStr {
+        ArcStr(FastStr::new(value))
+    }
+}
+
+impl<'a> From<Cow<'a, str>> for ArcStr {
+    fn from(value: Cow<'a, str>) -> ArcStr {
+        match value {
+            Cow::Borrowed(s) => s.into(),
+            Cow::Owned(s) => s.into(),
+        }
     }
 }
 
@@ -40,5 +86,27 @@ impl std::ops::Deref for ArcStr {
 impl log::kv::ToValue for ArcStr {
     fn to_value(&self) -> log::kv::Value {
         log::kv::Value::from_display(self)
+    }
+}
+
+#[cfg(feature = "pyo3")]
+mod pyo3_impl {
+    use std::borrow::Cow;
+
+    use pyo3::prelude::*;
+    use pyo3::types::PyString;
+
+    use crate::ArcStr;
+
+    impl<'py> FromPyObject<'py> for ArcStr {
+        fn extract_bound(value: &Bound<'py, PyAny>) -> PyResult<Self> {
+            Ok(ArcStr::from(value.extract::<Cow<str>>()?))
+        }
+    }
+
+    impl ToPyObject for ArcStr {
+        fn to_object(&self, py: Python<'_>) -> PyObject {
+            PyString::new_bound(py, &self).into()
+        }
     }
 }

--- a/eppo_core/src/str.rs
+++ b/eppo_core/src/str.rs
@@ -4,5 +4,41 @@
 
 use std::sync::Arc;
 
+use serde::{Deserialize, Serialize};
+
 /// `ArcStr` is a string that can be cloned cheaply.
-pub type ArcStr = Arc<str>;
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Deserialize, Serialize)]
+#[serde(transparent)]
+pub struct ArcStr(Arc<str>);
+
+impl std::fmt::Display for ArcStr {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl<T: Into<Arc<str>>> From<T> for ArcStr {
+    fn from(value: T) -> ArcStr {
+        ArcStr(value.into())
+    }
+}
+
+impl AsRef<str> for ArcStr {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl std::ops::Deref for ArcStr {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        self.as_ref()
+    }
+}
+
+impl log::kv::ToValue for ArcStr {
+    fn to_value(&self) -> log::kv::Value {
+        log::kv::Value::from_display(self)
+    }
+}

--- a/eppo_core/src/str.rs
+++ b/eppo_core/src/str.rs
@@ -1,0 +1,8 @@
+//! Some string type helpers.
+//!
+//! Moved into a separate module, so we could experiment with different representations.
+
+use std::sync::Arc;
+
+/// `ArcStr` is a string that can be cloned cheaply.
+pub type ArcStr = Arc<str>;

--- a/eppo_core/src/str.rs
+++ b/eppo_core/src/str.rs
@@ -8,18 +8,19 @@ use faststr::FastStr;
 
 use serde::{Deserialize, Serialize};
 
-/// `ArcStr` is a string that can be cloned cheaply.
+/// `Str` is a string optimized for cheap cloning. The implementation is hidden, so we can update it
+/// if we find faster implementation.
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Deserialize, Serialize)]
 #[serde(transparent)]
-pub struct ArcStr(FastStr);
+pub struct Str(FastStr);
 
-impl ArcStr {
-    pub fn new<S: AsRef<str>>(s: S) -> ArcStr {
-        ArcStr(FastStr::new(s))
+impl Str {
+    pub fn new<S: AsRef<str>>(s: S) -> Str {
+        Str(FastStr::new(s))
     }
 
-    pub fn from_static_str(s: &'static str) -> ArcStr {
-        ArcStr(FastStr::from_static_str(s))
+    pub fn from_static_str(s: &'static str) -> Str {
+        Str(FastStr::from_static_str(s))
     }
 
     pub fn as_str(&self) -> &str {
@@ -27,13 +28,13 @@ impl ArcStr {
     }
 }
 
-impl std::fmt::Debug for ArcStr {
+impl std::fmt::Debug for Str {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{:?}", self.0)
     }
 }
 
-impl std::fmt::Display for ArcStr {
+impl std::fmt::Display for Str {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str(&self.0)
     }
@@ -41,9 +42,9 @@ impl std::fmt::Display for ArcStr {
 
 macro_rules! impl_from_faststr {
     ($ty:ty) => {
-        impl From<$ty> for ArcStr {
-            fn from(value: $ty) -> ArcStr {
-                ArcStr(value.into())
+        impl From<$ty> for Str {
+            fn from(value: $ty) -> Str {
+                Str(value.into())
             }
         }
     };
@@ -52,16 +53,15 @@ macro_rules! impl_from_faststr {
 impl_from_faststr!(Arc<str>);
 impl_from_faststr!(Arc<String>);
 impl_from_faststr!(String);
-impl_from_faststr!(FastStr);
 
-impl<'a> From<&'a str> for ArcStr {
-    fn from(value: &'a str) -> ArcStr {
-        ArcStr(FastStr::new(value))
+impl<'a> From<&'a str> for Str {
+    fn from(value: &'a str) -> Str {
+        Str(FastStr::new(value))
     }
 }
 
-impl<'a> From<Cow<'a, str>> for ArcStr {
-    fn from(value: Cow<'a, str>) -> ArcStr {
+impl<'a> From<Cow<'a, str>> for Str {
+    fn from(value: Cow<'a, str>) -> Str {
         match value {
             Cow::Borrowed(s) => s.into(),
             Cow::Owned(s) => s.into(),
@@ -69,13 +69,13 @@ impl<'a> From<Cow<'a, str>> for ArcStr {
     }
 }
 
-impl AsRef<str> for ArcStr {
+impl AsRef<str> for Str {
     fn as_ref(&self) -> &str {
         &self.0
     }
 }
 
-impl std::ops::Deref for ArcStr {
+impl std::ops::Deref for Str {
     type Target = str;
 
     fn deref(&self) -> &Self::Target {
@@ -83,7 +83,7 @@ impl std::ops::Deref for ArcStr {
     }
 }
 
-impl log::kv::ToValue for ArcStr {
+impl log::kv::ToValue for Str {
     fn to_value(&self) -> log::kv::Value {
         log::kv::Value::from_display(self)
     }
@@ -96,15 +96,15 @@ mod pyo3_impl {
     use pyo3::prelude::*;
     use pyo3::types::PyString;
 
-    use crate::ArcStr;
+    use crate::Str;
 
-    impl<'py> FromPyObject<'py> for ArcStr {
+    impl<'py> FromPyObject<'py> for Str {
         fn extract_bound(value: &Bound<'py, PyAny>) -> PyResult<Self> {
-            Ok(ArcStr::from(value.extract::<Cow<str>>()?))
+            Ok(Str::from(value.extract::<Cow<str>>()?))
         }
     }
 
-    impl ToPyObject for ArcStr {
+    impl ToPyObject for Str {
         fn to_object(&self, py: Python<'_>) -> PyObject {
             PyString::new_bound(py, &self).into()
         }

--- a/eppo_core/src/ufc/assignment.rs
+++ b/eppo_core/src/ufc/assignment.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::events::AssignmentEvent;
+use crate::{events::AssignmentEvent, ArcStr};
 
 /// Result of assignment evaluation.
 #[derive(Debug, Serialize, Clone)]
@@ -17,7 +17,7 @@ pub struct Assignment {
 #[serde(tag = "type", content = "value", rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum AssignmentValue {
     /// A string value.
-    String(String),
+    String(ArcStr),
     /// An integer value.
     Integer(i64),
     /// A numeric value (floating-point).
@@ -37,7 +37,7 @@ impl AssignmentValue {
     /// # Examples
     /// ```
     /// # use eppo_core::ufc::AssignmentValue;
-    /// let value = AssignmentValue::String("example".to_owned());
+    /// let value = AssignmentValue::String("example".into());
     /// assert_eq!(value.is_string(), true);
     /// ```
     pub fn is_string(&self) -> bool {
@@ -51,7 +51,7 @@ impl AssignmentValue {
     /// # Examples
     /// ```
     /// # use eppo_core::ufc::AssignmentValue;
-    /// let value = AssignmentValue::String("example".to_owned());
+    /// let value = AssignmentValue::String("example".into());
     /// assert_eq!(value.as_str(), Some("example"));
     /// ```
     pub fn as_str(&self) -> Option<&str> {
@@ -69,10 +69,10 @@ impl AssignmentValue {
     /// # Examples
     /// ```
     /// # use eppo_core::ufc::AssignmentValue;
-    /// let value = AssignmentValue::String("example".to_owned());
-    /// assert_eq!(value.to_string(), Some("example".to_owned()));
+    /// let value = AssignmentValue::String("example".into());
+    /// assert_eq!(value.to_string(), Some("example".into()));
     /// ```
-    pub fn to_string(self) -> Option<String> {
+    pub fn to_string(self) -> Option<ArcStr> {
         match self {
             AssignmentValue::String(s) => Some(s),
             _ => None,

--- a/eppo_core/src/ufc/assignment.rs
+++ b/eppo_core/src/ufc/assignment.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use serde::{Deserialize, Serialize};
 
-use crate::{events::AssignmentEvent, ArcStr};
+use crate::{events::AssignmentEvent, Str};
 
 /// Result of assignment evaluation.
 #[derive(Debug, Serialize, Clone)]
@@ -19,7 +19,7 @@ pub struct Assignment {
 #[serde(tag = "type", content = "value", rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum AssignmentValue {
     /// A string value.
-    String(ArcStr),
+    String(Str),
     /// An integer value.
     Integer(i64),
     /// A numeric value (floating-point).
@@ -74,7 +74,7 @@ impl AssignmentValue {
     /// let value = AssignmentValue::String("example".into());
     /// assert_eq!(value.to_string(), Some("example".into()));
     /// ```
-    pub fn to_string(self) -> Option<ArcStr> {
+    pub fn to_string(self) -> Option<Str> {
         match self {
             AssignmentValue::String(s) => Some(s),
             _ => None,

--- a/eppo_core/src/ufc/assignment.rs
+++ b/eppo_core/src/ufc/assignment.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use crate::events::AssignmentEvent;
 
 /// Result of assignment evaluation.
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Assignment {
     /// Assignment value that should be returned to the user.

--- a/eppo_core/src/ufc/assignment.rs
+++ b/eppo_core/src/ufc/assignment.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use serde::{Deserialize, Serialize};
 
 use crate::{events::AssignmentEvent, ArcStr};
@@ -25,7 +27,7 @@ pub enum AssignmentValue {
     /// A boolean value.
     Boolean(bool),
     /// Arbitrary JSON value.
-    Json(serde_json::Value),
+    Json(Arc<serde_json::Value>),
 }
 
 impl AssignmentValue {
@@ -185,7 +187,7 @@ impl AssignmentValue {
     /// # use eppo_core::ufc::AssignmentValue;
     /// use serde_json::json;
     ///
-    /// let value = AssignmentValue::Json(json!({ "key": "value" }));
+    /// let value = AssignmentValue::Json(json!({ "key": "value" }).into());
     /// assert_eq!(value.is_json(), true);
     /// ```
     pub fn is_json(&self) -> bool {
@@ -201,7 +203,7 @@ impl AssignmentValue {
     /// # use eppo_core::ufc::AssignmentValue;
     /// use serde_json::json;
     ///
-    /// let value = AssignmentValue::Json(json!({ "key": "value" }));
+    /// let value = AssignmentValue::Json(json!({ "key": "value" }).into());
     /// assert_eq!(value.as_json(), Some(&json!({ "key": "value" })));
     /// ```
     pub fn as_json(&self) -> Option<&serde_json::Value> {
@@ -220,10 +222,10 @@ impl AssignmentValue {
     /// # use eppo_core::ufc::AssignmentValue;
     /// use serde_json::json;
     ///
-    /// let value = AssignmentValue::Json(json!({ "key": "value" }));
-    /// assert_eq!(value.to_json(), Some(json!({ "key": "value" })));
+    /// let value = AssignmentValue::Json(json!({ "key": "value" }).into());
+    /// assert_eq!(value.to_json(), Some(json!({ "key": "value" }).into()));
     /// ```
-    pub fn to_json(self) -> Option<serde_json::Value> {
+    pub fn to_json(self) -> Option<Arc<serde_json::Value>> {
         match self {
             Self::Json(v) => Some(v),
             _ => None,

--- a/eppo_core/src/ufc/compiled_flag_config.rs
+++ b/eppo_core/src/ufc/compiled_flag_config.rs
@@ -6,7 +6,7 @@ use crate::{
     error::EvaluationFailure,
     events::{AssignmentEventBase, EventMetaData},
     sharder::PreSaltedSharder,
-    ArcStr, Error, EvaluationError, SdkMetadata,
+    Error, EvaluationError, SdkMetadata, Str,
 };
 
 use super::{
@@ -47,7 +47,7 @@ pub(crate) struct Flag {
 
 #[derive(Debug)]
 pub(crate) struct Allocation {
-    pub key: ArcStr, // key is here to support evaluation details
+    pub key: Str, // key is here to support evaluation details
     pub start_at: Option<Timestamp>,
     pub end_at: Option<Timestamp>,
     pub rules: Box<[RuleWire]>,
@@ -57,7 +57,7 @@ pub(crate) struct Allocation {
 #[derive(Debug)]
 pub(crate) struct Split {
     pub shards: Vec<Shard>,
-    pub variation_key: ArcStr, // for evaluation details
+    pub variation_key: Str, // for evaluation details
     // This is a Result because it may still return a configuration error (invalid value for
     // assignment type).
     pub result: Result<(AssignmentValue, Option<Arc<AssignmentEventBase>>), EvaluationFailure>,
@@ -172,9 +172,9 @@ fn compile_flag(meta_data: EventMetaData, flag: FlagWire) -> Flag {
 
 fn compile_allocation(
     meta_data: EventMetaData,
-    flag_key: &ArcStr,
+    flag_key: &Str,
     allocation: AllocationWire,
-    variation_values: &HashMap<ArcStr, Result<AssignmentValue, EvaluationFailure>>,
+    variation_values: &HashMap<Str, Result<AssignmentValue, EvaluationFailure>>,
     total_shards: u32,
 ) -> Allocation {
     let splits = allocation
@@ -203,10 +203,10 @@ fn compile_allocation(
 
 fn compile_split(
     meta_data: EventMetaData,
-    flag_key: &ArcStr,
-    allocation_key: &ArcStr,
+    flag_key: &Str,
+    allocation_key: &Str,
     split: SplitWire,
-    variation_values: &HashMap<ArcStr, Result<AssignmentValue, EvaluationFailure>>,
+    variation_values: &HashMap<Str, Result<AssignmentValue, EvaluationFailure>>,
     total_shards: u32,
     do_log: bool,
 ) -> Split {

--- a/eppo_core/src/ufc/compiled_flag_config.rs
+++ b/eppo_core/src/ufc/compiled_flag_config.rs
@@ -1,0 +1,273 @@
+use std::{collections::HashMap, sync::Arc};
+
+use serde::Serialize;
+
+use crate::{
+    error::EvaluationFailure,
+    events::{AssignmentEventBase, EventMetaData},
+    ArcStr, Error, EvaluationError, SdkMetadata,
+};
+
+use super::{
+    AllocationWire, AssignmentValue, BanditVariationWire, Environment, FlagWire, RuleWire,
+    ShardRange, ShardWire, SplitWire, Timestamp, UniversalFlagConfigWire, VariationType,
+};
+
+#[derive(Debug)]
+pub struct UniversalFlagConfig {
+    /// Original JSON the configuration was compiled from.
+    pub(crate) wire_json: Vec<u8>,
+    pub(crate) compiled: CompiledFlagsConfig,
+}
+
+#[derive(Debug)]
+pub(crate) struct CompiledFlagsConfig {
+    /// When configuration was last updated.
+    pub created_at: Timestamp,
+    /// Environment this configuration belongs to.
+    pub environment: Environment,
+    /// Flags configuration.
+    ///
+    /// For flags that failed to parse or are disabled, we store the evaluation failure directly.
+    pub flags: HashMap<String, Result<Flag, EvaluationFailure>>,
+    /// Mapping from flag key to flag variation value to bandit variation. Cached from
+    /// `UniversalFlagConfig::bandits`.
+    pub flag_to_bandit_associations: HashMap<
+        /* flag_key: */ String,
+        HashMap</* variation_key: */ String, BanditVariationWire>,
+    >,
+}
+
+#[derive(Debug)]
+pub(crate) struct Flag {
+    pub variation_type: VariationType,
+    pub allocations: Box<[Allocation]>,
+}
+
+#[derive(Debug)]
+pub(crate) struct Allocation {
+    pub key: ArcStr, // key is here to support evaluation details
+    pub start_at: Option<Timestamp>,
+    pub end_at: Option<Timestamp>,
+    pub rules: Box<[RuleWire]>,
+    pub splits: Box<[Split]>,
+}
+
+#[derive(Debug)]
+pub(crate) struct Split {
+    pub shards: Option<Box<[Shard]>>,
+    pub variation_key: ArcStr, // for evaluation details
+    // This is a Result because it may still return a configuration error (invalid value for
+    // assignment type).
+    pub result: Result<(AssignmentValue, Option<Arc<AssignmentEventBase>>), EvaluationFailure>,
+}
+
+#[derive(Clone, Serialize)]
+pub struct Shard {
+    #[serde(skip)]
+    pub(crate) md5_context: md5::Context,
+    pub total_shards: u32,
+    pub ranges: Box<[ShardRange]>,
+}
+
+// Cannot derive as md5::Context is not Debug.
+impl std::fmt::Debug for Shard {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CompiledShard")
+            .field("md5_context", &"...")
+            .field("total_shards", &self.total_shards)
+            .field("ranges", &self.ranges)
+            .finish()
+    }
+}
+
+impl UniversalFlagConfig {
+    pub fn from_json(meta_data: SdkMetadata, json: Vec<u8>) -> Result<Self, Error> {
+        let config: UniversalFlagConfigWire = serde_json::from_slice(&json).map_err(|err| {
+            log::warn!(target: "eppo", "failed to compile flag configuration: {err:?}");
+            Error::EvaluationError(EvaluationError::UnexpectedConfigurationParseError)
+        })?;
+        Ok(UniversalFlagConfig {
+            wire_json: json,
+            compiled: compile_flag_configuration(meta_data.into(), config),
+        })
+    }
+
+    pub fn to_json(&self) -> &[u8] {
+        &self.wire_json
+    }
+}
+
+fn compile_flag_configuration(
+    meta_data: EventMetaData,
+    config: UniversalFlagConfigWire,
+) -> CompiledFlagsConfig {
+    let flags = config
+        .flags
+        .into_iter()
+        .map(|(key, flag)| {
+            (
+                key,
+                Option::from(flag)
+                    .ok_or(EvaluationFailure::Error(
+                        EvaluationError::UnexpectedConfigurationParseError,
+                    ))
+                    .and_then(|flag: FlagWire| {
+                        if flag.enabled {
+                            Ok(compile_flag(meta_data, flag))
+                        } else {
+                            Err(EvaluationFailure::FlagDisabled)
+                        }
+                    }),
+            )
+        })
+        .collect();
+
+    CompiledFlagsConfig {
+        created_at: config.created_at,
+        environment: config.environment,
+        flags,
+        flag_to_bandit_associations: get_flag_to_bandit_associations(config.bandits),
+    }
+}
+
+fn get_flag_to_bandit_associations(
+    bandits: HashMap<String, Vec<BanditVariationWire>>,
+) -> HashMap<String, HashMap<String, BanditVariationWire>> {
+    bandits
+        .into_iter()
+        .flat_map(|(_, bandits)| bandits.into_iter())
+        .fold(HashMap::new(), |mut acc, variation| {
+            acc.entry(variation.flag_key.clone())
+                .or_default()
+                .insert(variation.variation_value.clone(), variation);
+            acc
+        })
+}
+
+fn compile_flag(meta_data: EventMetaData, flag: FlagWire) -> Flag {
+    let variation_values = flag
+        .variations
+        .into_values()
+        .map(|variation| {
+            let assignment_value = variation
+                .value
+                .to_assignment_value(flag.variation_type)
+                .ok_or(EvaluationFailure::Error(
+                    EvaluationError::UnexpectedConfigurationError,
+                ));
+
+            (variation.key, assignment_value)
+        })
+        .collect::<HashMap<_, _>>();
+
+    let allocations = flag
+        .allocations
+        .into_iter()
+        .map(|allocation| {
+            compile_allocation(
+                meta_data,
+                &flag.key,
+                allocation,
+                &variation_values,
+                flag.total_shards,
+            )
+        })
+        .collect();
+
+    Flag {
+        variation_type: flag.variation_type,
+        allocations,
+    }
+}
+
+fn compile_allocation(
+    meta_data: EventMetaData,
+    flag_key: &ArcStr,
+    allocation: AllocationWire,
+    variation_values: &HashMap<ArcStr, Result<AssignmentValue, EvaluationFailure>>,
+    total_shards: u32,
+) -> Allocation {
+    let splits = allocation
+        .splits
+        .into_iter()
+        .map(|split| {
+            compile_split(
+                meta_data,
+                flag_key,
+                &allocation.key,
+                split,
+                variation_values,
+                total_shards,
+                allocation.do_log,
+            )
+        })
+        .collect();
+    Allocation {
+        key: allocation.key,
+        start_at: allocation.start_at,
+        end_at: allocation.end_at,
+        rules: allocation.rules,
+        splits,
+    }
+}
+
+fn compile_split(
+    meta_data: EventMetaData,
+    flag_key: &ArcStr,
+    allocation_key: &ArcStr,
+    split: SplitWire,
+    variation_values: &HashMap<ArcStr, Result<AssignmentValue, EvaluationFailure>>,
+    total_shards: u32,
+    do_log: bool,
+) -> Split {
+    let shards = if split.shards.is_empty() {
+        None
+    } else {
+        Some(
+            split
+                .shards
+                .into_iter()
+                .map(|shard| compile_shard(shard, total_shards))
+                .collect(),
+        )
+    };
+
+    let result = variation_values
+        .get(&split.variation_key)
+        .cloned()
+        .unwrap_or(Err(EvaluationFailure::Error(
+            EvaluationError::UnexpectedConfigurationError,
+        )))
+        .map(|value| {
+            let event = do_log.then(|| {
+                Arc::new(AssignmentEventBase {
+                    experiment: format!("{flag_key}-{allocation_key}"),
+                    feature_flag: flag_key.clone(),
+                    allocation: allocation_key.clone(),
+                    variation: split.variation_key.clone(),
+                    meta_data,
+                    extra_logging: split.extra_logging,
+                })
+            });
+            (value, event)
+        });
+
+    Split {
+        shards,
+        variation_key: split.variation_key,
+        result,
+    }
+}
+
+fn compile_shard(shard: ShardWire, total_shards: u32) -> Shard {
+    let mut md5_context = md5::Context::new();
+    md5_context.consume(shard.salt);
+    md5_context.consume(b"-");
+
+    Shard {
+        md5_context,
+        total_shards,
+        ranges: shard.ranges,
+    }
+}

--- a/eppo_core/src/ufc/compiled_flag_config.rs
+++ b/eppo_core/src/ufc/compiled_flag_config.rs
@@ -152,7 +152,7 @@ fn compile_flag(meta_data: EventMetaData, flag: FlagWire) -> Flag {
         .map(|variation| {
             let assignment_value = variation
                 .value
-                .to_assignment_value(flag.variation_type)
+                .into_assignment_value(flag.variation_type)
                 .ok_or(EvaluationFailure::Error(
                     EvaluationError::UnexpectedConfigurationError,
                 ));

--- a/eppo_core/src/ufc/mod.rs
+++ b/eppo_core/src/ufc/mod.rs
@@ -1,6 +1,8 @@
 //! Universal Flag Configuration.
 mod assignment;
+mod compiled_flag_config;
 mod models;
 
 pub use assignment::{Assignment, AssignmentValue};
+pub use compiled_flag_config::*;
 pub use models::*;

--- a/eppo_core/src/ufc/models.rs
+++ b/eppo_core/src/ufc/models.rs
@@ -5,7 +5,7 @@ use regex::Regex;
 use semver::Version;
 use serde::{Deserialize, Serialize};
 
-use crate::{ArcStr, Error, EvaluationError};
+use crate::{Error, EvaluationError, Str};
 
 use super::AssignmentValue;
 
@@ -35,7 +35,7 @@ pub(crate) struct UniversalFlagConfigWire {
 #[serde(rename_all = "camelCase")]
 pub(crate) struct Environment {
     /// Name of the environment.
-    pub name: ArcStr,
+    pub name: Str,
 }
 
 /// `TryParse` allows the subfield to fail parsing without failing the parsing of the whole
@@ -77,7 +77,7 @@ impl<'a, T> From<&'a TryParse<T>> for Option<&'a T> {
 #[serde(rename_all = "camelCase")]
 #[allow(missing_docs)]
 pub(crate) struct FlagWire {
-    pub key: ArcStr,
+    pub key: Str,
     pub enabled: bool,
     pub variation_type: VariationType,
     pub variations: HashMap<String, VariationWire>,
@@ -109,7 +109,7 @@ pub(crate) enum ValueWire {
     /// Number maps to either [`AssignmentValue::Integer`] or [`AssignmentValue::Numeric`].
     Number(f64),
     /// String maps to either [`AssignmentValue::String`] or [`AssignmentValue::Json`].
-    String(ArcStr),
+    String(Str),
 }
 
 impl ValueWire {
@@ -148,7 +148,7 @@ impl ValueWire {
         }
     }
 
-    fn into_string(self) -> Option<ArcStr> {
+    fn into_string(self) -> Option<Str> {
         match self {
             Self::String(value) => Some(value),
             _ => None,
@@ -165,7 +165,7 @@ impl ValueWire {
 #[serde(rename_all = "camelCase")]
 #[allow(missing_docs)]
 pub(crate) struct VariationWire {
-    pub key: ArcStr,
+    pub key: Str,
     pub value: ValueWire,
 }
 
@@ -173,7 +173,7 @@ pub(crate) struct VariationWire {
 #[serde(rename_all = "camelCase")]
 #[allow(missing_docs)]
 pub(crate) struct AllocationWire {
-    pub key: ArcStr,
+    pub key: Str,
     #[serde(default)]
     pub rules: Box<[RuleWire]>,
     #[serde(default)]
@@ -287,7 +287,7 @@ impl From<Condition> for ConditionWire {
                 } else {
                     ConditionOperator::NotMatches
                 },
-                ConditionValue::Single(ValueWire::String(ArcStr::from(regex.as_str()))),
+                ConditionValue::Single(ValueWire::String(Str::from(regex.as_str()))),
             ),
             ConditionCheck::Membership {
                 expected_membership,
@@ -482,7 +482,7 @@ impl From<Vec<String>> for ConditionValue {
 #[allow(missing_docs)]
 pub(crate) struct SplitWire {
     pub shards: Vec<ShardWire>,
-    pub variation_key: ArcStr,
+    pub variation_key: Str,
     #[serde(default)]
     pub extra_logging: HashMap<String, String>,
 }

--- a/eppo_core/src/ufc/models.rs
+++ b/eppo_core/src/ufc/models.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, sync::Arc};
+use std::collections::HashMap;
 
 use derive_more::From;
 use regex::Regex;
@@ -15,7 +15,7 @@ pub type Timestamp = chrono::DateTime<chrono::Utc>;
 /// Universal Flag Configuration. This the response format from the UFC endpoint.
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
-pub struct UniversalFlagConfig {
+pub(crate) struct UniversalFlagConfigWire {
     /// When configuration was last updated.
     pub created_at: Timestamp,
     /// Environment this configuration belongs to.
@@ -24,16 +24,16 @@ pub struct UniversalFlagConfig {
     ///
     /// Value is wrapped in `TryParse` so that if we fail to parse one flag (e.g., new server
     /// format), we can still serve other flags.
-    pub flags: HashMap<String, TryParse<Flag>>,
+    pub flags: HashMap<String, TryParse<FlagWire>>,
     /// `bandits` field connects string feature flags to bandits. Actual bandits configuration is
     /// served separately.
     #[serde(default)]
-    pub bandits: HashMap<String, Vec<BanditVariation>>,
+    pub bandits: HashMap<String, Vec<BanditVariationWire>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct Environment {
+pub(crate) struct Environment {
     /// Name of the environment.
     pub name: ArcStr,
 }
@@ -49,22 +49,11 @@ pub enum TryParse<T> {
     /// Successfully parsed.
     Parsed(T),
     /// Parsing failed.
-    ///
-    /// This holds the generic JSON value, so even if parsing originally failed, we could serialize
-    /// the value back to JSON.
     ParseFailed(serde_json::Value),
 }
 impl<T> From<T> for TryParse<T> {
     fn from(value: T) -> TryParse<T> {
         TryParse::Parsed(value)
-    }
-}
-impl<T> From<TryParse<T>> for Result<T, serde_json::Value> {
-    fn from(value: TryParse<T>) -> Self {
-        match value {
-            TryParse::Parsed(v) => Ok(v),
-            TryParse::ParseFailed(v) => Err(v),
-        }
     }
 }
 impl<T> From<TryParse<T>> for Option<T> {
@@ -87,13 +76,13 @@ impl<'a, T> From<&'a TryParse<T>> for Option<&'a T> {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 #[allow(missing_docs)]
-pub struct Flag {
+pub(crate) struct FlagWire {
     pub key: ArcStr,
     pub enabled: bool,
     pub variation_type: VariationType,
-    pub variations: HashMap<String, Variation>,
-    pub allocations: Vec<Allocation>,
-    pub total_shards: u64,
+    pub variations: HashMap<String, VariationWire>,
+    pub allocations: Vec<AllocationWire>,
+    pub total_shards: u32,
 }
 
 /// Type of the variation.
@@ -114,7 +103,7 @@ pub enum VariationType {
 /// combine it with [`VariationType`] from the flag level.
 #[derive(Debug, Serialize, Deserialize, PartialEq, From, Clone)]
 #[serde(untagged)]
-pub enum Value {
+pub(crate) enum ValueWire {
     /// Boolean maps to [`AssignmentValue::Boolean`].
     Boolean(bool),
     /// Number maps to either [`AssignmentValue::Integer`] or [`AssignmentValue::Numeric`].
@@ -123,7 +112,7 @@ pub enum Value {
     String(String),
 }
 
-impl Value {
+impl ValueWire {
     /// Try to convert `Value` to [`AssignmentValue`] under the given [`VariationType`].
     pub(crate) fn to_assignment_value(&self, ty: VariationType) -> Option<AssignmentValue> {
         Some(match ty {
@@ -172,7 +161,7 @@ impl Value {
     }
 }
 
-impl From<&str> for Value {
+impl From<&str> for ValueWire {
     fn from(value: &str) -> Self {
         Self::String(value.to_owned())
     }
@@ -181,23 +170,23 @@ impl From<&str> for Value {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 #[allow(missing_docs)]
-pub struct Variation {
+pub(crate) struct VariationWire {
     pub key: ArcStr,
-    pub value: Value,
+    pub value: ValueWire,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 #[allow(missing_docs)]
-pub struct Allocation {
+pub(crate) struct AllocationWire {
     pub key: ArcStr,
     #[serde(default)]
-    pub rules: Vec<Rule>,
+    pub rules: Box<[RuleWire]>,
     #[serde(default)]
     pub start_at: Option<Timestamp>,
     #[serde(default)]
     pub end_at: Option<Timestamp>,
-    pub splits: Vec<Split>,
+    pub splits: Vec<SplitWire>,
     #[serde(default = "default_do_log")]
     pub do_log: bool,
 }
@@ -209,7 +198,7 @@ fn default_do_log() -> bool {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[allow(missing_docs)]
-pub struct Rule {
+pub(crate) struct RuleWire {
     pub conditions: Vec<TryParse<Condition>>,
 }
 
@@ -217,13 +206,13 @@ pub struct Rule {
 /// `operator`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(try_from = "ConditionWire", into = "ConditionWire")]
-pub struct Condition {
+pub(crate) struct Condition {
     pub attribute: Box<str>,
     pub check: ConditionCheck,
 }
 
 #[derive(Debug, Clone)]
-pub enum ConditionCheck {
+pub(crate) enum ConditionCheck {
     Comparison {
         operator: ComparisonOperator,
         comparand: Comparand,
@@ -244,7 +233,7 @@ pub enum ConditionCheck {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub enum ComparisonOperator {
+pub(crate) enum ComparisonOperator {
     Gte,
     Gt,
     Lte,
@@ -263,7 +252,7 @@ impl From<ComparisonOperator> for ConditionOperator {
 }
 
 #[derive(Debug, Clone, PartialEq, PartialOrd, From)]
-pub enum Comparand {
+pub(crate) enum Comparand {
     Version(Version),
     Number(f64),
 }
@@ -282,7 +271,7 @@ impl From<Comparand> for ConditionValue {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[allow(missing_docs)]
-pub struct ConditionWire {
+pub(crate) struct ConditionWire {
     pub attribute: Box<str>,
     pub operator: ConditionOperator,
     pub value: ConditionValue,
@@ -345,7 +334,7 @@ impl TryFrom<ConditionWire> for Condition {
                 let expected_match = condition.operator == ConditionOperator::Matches;
 
                 let regex_string = match condition.value {
-                    ConditionValue::Single(Value::String(s)) => s,
+                    ConditionValue::Single(ValueWire::String(s)) => s,
                     _ => {
                         log::warn!(
                             "failed to parse condition: {:?} condition with non-string condition value",
@@ -384,7 +373,7 @@ impl TryFrom<ConditionWire> for Condition {
                 };
 
                 let condition_version = match &condition.value {
-                    ConditionValue::Single(Value::String(s)) => Version::parse(s).ok(),
+                    ConditionValue::Single(ValueWire::String(s)) => Version::parse(s).ok(),
                     _ => None,
                 };
 
@@ -396,8 +385,8 @@ impl TryFrom<ConditionWire> for Condition {
                 } else {
                     // numeric comparison
                     let condition_value = match &condition.value {
-                        ConditionValue::Single(Value::Number(n)) => Some(*n),
-                        ConditionValue::Single(Value::String(s)) => s.parse().ok(),
+                        ConditionValue::Single(ValueWire::Number(n)) => Some(*n),
+                        ConditionValue::Single(ValueWire::String(s)) => s.parse().ok(),
                         _ => None,
                     };
                     let Some(condition_value) = condition_value else {
@@ -429,7 +418,8 @@ impl TryFrom<ConditionWire> for Condition {
                 }
             }
             ConditionOperator::IsNull => {
-                let ConditionValue::Single(Value::Boolean(expected_null)) = condition.value else {
+                let ConditionValue::Single(ValueWire::Boolean(expected_null)) = condition.value
+                else {
                     log::warn!("failed to parse condition: IS_NULL condition with non-boolean condition value");
                     return Err(Error::EvaluationError(
                         EvaluationError::UnexpectedConfigurationParseError,
@@ -445,7 +435,7 @@ impl TryFrom<ConditionWire> for Condition {
 /// Possible condition types.
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, Copy)]
 #[serde(rename_all = "SCREAMING_SNAKE_CASE")]
-pub enum ConditionOperator {
+pub(crate) enum ConditionOperator {
     /// Matches regex. Condition value must be a regex string.
     Matches,
     /// Regex does not match. Condition value must be a regex string.
@@ -476,13 +466,13 @@ pub enum ConditionOperator {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(untagged)]
 #[allow(missing_docs)]
-pub enum ConditionValue {
-    Single(Value),
+pub(crate) enum ConditionValue {
+    Single(ValueWire),
     // Only string arrays are currently supported.
     Multiple(Box<[Box<str>]>),
 }
 
-impl<T: Into<Value>> From<T> for ConditionValue {
+impl<T: Into<ValueWire>> From<T> for ConditionValue {
     fn from(value: T) -> Self {
         Self::Single(value.into())
     }
@@ -496,30 +486,30 @@ impl From<Vec<String>> for ConditionValue {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 #[allow(missing_docs)]
-pub struct Split {
-    pub shards: Vec<Shard>,
-    pub variation_key: String,
+pub(crate) struct SplitWire {
+    pub shards: Vec<ShardWire>,
+    pub variation_key: ArcStr,
     #[serde(default)]
-    pub extra_logging: Arc<HashMap<String, String>>,
+    pub extra_logging: HashMap<String, String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[allow(missing_docs)]
-pub struct Shard {
+pub(crate) struct ShardWire {
     pub salt: String,
-    pub ranges: Vec<ShardRange>,
+    pub ranges: Box<[ShardRange]>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[allow(missing_docs)]
 pub struct ShardRange {
-    pub start: u64,
-    pub end: u64,
+    pub start: u32,
+    pub end: u32,
 }
 impl ShardRange {
-    pub(crate) fn contains(&self, v: u64) -> bool {
+    pub(crate) fn contains(&self, v: u32) -> bool {
         self.start <= v && v < self.end
     }
 }
@@ -527,7 +517,7 @@ impl ShardRange {
 /// `BanditVariation` associates a variation in feature flag with a bandit.
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
-pub struct BanditVariation {
+pub(crate) struct BanditVariationWire {
     pub key: String,
     /// Key of the flag.
     pub flag_key: String,
@@ -541,18 +531,18 @@ pub struct BanditVariation {
 mod tests {
     use std::{fs::File, io::BufReader};
 
-    use super::{TryParse, UniversalFlagConfig};
+    use super::{TryParse, UniversalFlagConfigWire};
 
     #[test]
     fn parse_flags_v1() {
         let f = File::open("../sdk-test-data/ufc/flags-v1.json")
             .expect("Failed to open ../sdk-test-data/ufc/flags-v1.json");
-        let _ufc: UniversalFlagConfig = serde_json::from_reader(BufReader::new(f)).unwrap();
+        let _ufc: UniversalFlagConfigWire = serde_json::from_reader(BufReader::new(f)).unwrap();
     }
 
     #[test]
     fn parse_partially_if_unexpected() {
-        let ufc: UniversalFlagConfig = serde_json::from_str(
+        let ufc: UniversalFlagConfigWire = serde_json::from_str(
             &r#"
               {
                 "createdAt": "2024-07-18T00:00:00Z",

--- a/eppo_core/src/ufc/models.rs
+++ b/eppo_core/src/ufc/models.rs
@@ -161,12 +161,6 @@ impl ValueWire {
     }
 }
 
-impl From<&str> for ValueWire {
-    fn from(value: &str) -> Self {
-        ValueWire::String(ArcStr::from(value))
-    }
-}
-
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]
 #[allow(missing_docs)]
@@ -263,7 +257,7 @@ impl From<Comparand> for ConditionValue {
             Comparand::Version(v) => v.to_string(),
             Comparand::Number(n) => n.to_string(),
         };
-        ConditionValue::Single(s.as_str().into())
+        ConditionValue::Single(ValueWire::String(s.into()))
     }
 }
 
@@ -293,7 +287,7 @@ impl From<Condition> for ConditionWire {
                 } else {
                     ConditionOperator::NotMatches
                 },
-                regex.as_str().into(),
+                ConditionValue::Single(ValueWire::String(ArcStr::from(regex.as_str()))),
             ),
             ConditionCheck::Membership {
                 expected_membership,

--- a/eppo_core/src/ufc/models.rs
+++ b/eppo_core/src/ufc/models.rs
@@ -1,11 +1,11 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::Arc};
 
 use derive_more::From;
 use regex::Regex;
 use semver::Version;
 use serde::{Deserialize, Serialize};
 
-use crate::{Error, EvaluationError};
+use crate::{ArcStr, Error, EvaluationError};
 
 use super::AssignmentValue;
 
@@ -35,7 +35,7 @@ pub struct UniversalFlagConfig {
 #[serde(rename_all = "camelCase")]
 pub struct Environment {
     /// Name of the environment.
-    pub name: String,
+    pub name: ArcStr,
 }
 
 /// `TryParse` allows the subfield to fail parsing without failing the parsing of the whole
@@ -88,7 +88,7 @@ impl<'a, T> From<&'a TryParse<T>> for Option<&'a T> {
 #[serde(rename_all = "camelCase")]
 #[allow(missing_docs)]
 pub struct Flag {
-    pub key: String,
+    pub key: ArcStr,
     pub enabled: bool,
     pub variation_type: VariationType,
     pub variations: HashMap<String, Variation>,
@@ -182,7 +182,7 @@ impl From<&str> for Value {
 #[serde(rename_all = "camelCase")]
 #[allow(missing_docs)]
 pub struct Variation {
-    pub key: String,
+    pub key: ArcStr,
     pub value: Value,
 }
 
@@ -190,7 +190,7 @@ pub struct Variation {
 #[serde(rename_all = "camelCase")]
 #[allow(missing_docs)]
 pub struct Allocation {
-    pub key: String,
+    pub key: ArcStr,
     #[serde(default)]
     pub rules: Vec<Rule>,
     #[serde(default)]
@@ -500,7 +500,7 @@ pub struct Split {
     pub shards: Vec<Shard>,
     pub variation_key: String,
     #[serde(default)]
-    pub extra_logging: HashMap<String, String>,
+    pub extra_logging: Arc<HashMap<String, String>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/eppo_core/src/ufc/models.rs
+++ b/eppo_core/src/ufc/models.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::Arc};
 
 use derive_more::From;
 use regex::Regex;
@@ -120,7 +120,7 @@ impl ValueWire {
             VariationType::Integer => AssignmentValue::Integer(self.as_integer()?),
             VariationType::Numeric => AssignmentValue::Numeric(self.as_number()?),
             VariationType::Boolean => AssignmentValue::Boolean(self.as_boolean()?),
-            VariationType::Json => AssignmentValue::Json(self.into_json()?),
+            VariationType::Json => AssignmentValue::Json(Arc::new(self.into_json()?)),
         })
     }
 

--- a/python-sdk/src/client.rs
+++ b/python-sdk/src/client.rs
@@ -375,7 +375,7 @@ impl EppoClient {
 
         let mut result = this.evaluator.get_bandit_action(
             flag_key,
-            subject_key,
+            &subject_key.into(),
             &subject_context,
             &actions,
             default,
@@ -408,7 +408,7 @@ impl EppoClient {
 
         let (mut result, details) = this.evaluator.get_bandit_action_details(
             flag_key,
-            subject_key,
+            &subject_key.into(),
             &subject_context,
             &actions,
             default,
@@ -621,8 +621,8 @@ impl EppoClient {
     ) -> PyResult<PyObject> {
         let result = self.evaluator.get_assignment(
             &flag_key,
-            &subject_key,
-            &subject_attributes,
+            &subject_key.into(),
+            &subject_attributes.into(),
             expected_type,
         );
 
@@ -661,8 +661,8 @@ impl EppoClient {
     ) -> PyResult<EvaluationResult> {
         let (result, event) = self.evaluator.get_assignment_details(
             &flag_key,
-            &subject_key,
-            &subject_attributes,
+            &subject_key.into(),
+            &subject_attributes.into(),
             expected_type,
         );
 

--- a/python-sdk/src/client.rs
+++ b/python-sdk/src/client.rs
@@ -379,7 +379,7 @@ impl EppoClient {
             &subject_key.into(),
             &subject_context,
             &actions,
-            default,
+            &default.into(),
         );
 
         if let Some(event) = result.assignment_event.take() {
@@ -412,7 +412,7 @@ impl EppoClient {
             &subject_key.into(),
             &subject_context,
             &actions,
-            default,
+            &default.into(),
         );
 
         if let Some(event) = result.assignment_event.take() {

--- a/python-sdk/src/client.rs
+++ b/python-sdk/src/client.rs
@@ -27,7 +27,7 @@ use eppo_core::{
     poller_thread::{PollerThread, PollerThreadConfig},
     pyo3::TryToPyObject,
     ufc::VariationType,
-    Attributes, ContextAttributes,
+    ArcStr, Attributes, ContextAttributes,
 };
 
 use crate::{
@@ -152,7 +152,7 @@ impl EppoClient {
     fn get_string_assignment(
         slf: &Bound<EppoClient>,
         flag_key: &str,
-        subject_key: &str,
+        subject_key: ArcStr,
         subject_attributes: Attributes,
         default: Py<PyString>,
     ) -> PyResult<PyObject> {
@@ -168,7 +168,7 @@ impl EppoClient {
     fn get_integer_assignment(
         slf: &Bound<EppoClient>,
         flag_key: &str,
-        subject_key: &str,
+        subject_key: ArcStr,
         subject_attributes: Attributes,
         default: Py<PyInt>,
     ) -> PyResult<PyObject> {
@@ -184,7 +184,7 @@ impl EppoClient {
     fn get_numeric_assignment(
         slf: &Bound<EppoClient>,
         flag_key: &str,
-        subject_key: &str,
+        subject_key: ArcStr,
         subject_attributes: Attributes,
         default: Py<PyFloat>,
     ) -> PyResult<PyObject> {
@@ -200,7 +200,7 @@ impl EppoClient {
     fn get_boolean_assignment(
         slf: &Bound<EppoClient>,
         flag_key: &str,
-        subject_key: &str,
+        subject_key: ArcStr,
         subject_attributes: Attributes,
         default: Py<PyBool>,
     ) -> PyResult<PyObject> {
@@ -216,7 +216,7 @@ impl EppoClient {
     fn get_json_assignment(
         slf: &Bound<EppoClient>,
         flag_key: &str,
-        subject_key: &str,
+        subject_key: ArcStr,
         subject_attributes: Attributes,
         default: PyObject,
     ) -> PyResult<PyObject> {
@@ -233,7 +233,7 @@ impl EppoClient {
     fn get_string_assignment_details(
         slf: &Bound<EppoClient>,
         flag_key: &str,
-        subject_key: &str,
+        subject_key: ArcStr,
         subject_attributes: Attributes,
         default: Py<PyString>,
     ) -> PyResult<EvaluationResult> {
@@ -249,7 +249,7 @@ impl EppoClient {
     fn get_integer_assignment_details(
         slf: &Bound<EppoClient>,
         flag_key: &str,
-        subject_key: &str,
+        subject_key: ArcStr,
         subject_attributes: Attributes,
         default: Py<PyInt>,
     ) -> PyResult<EvaluationResult> {
@@ -265,7 +265,7 @@ impl EppoClient {
     fn get_numeric_assignment_details(
         slf: &Bound<EppoClient>,
         flag_key: &str,
-        subject_key: &str,
+        subject_key: ArcStr,
         subject_attributes: Attributes,
         default: Py<PyFloat>,
     ) -> PyResult<EvaluationResult> {
@@ -281,7 +281,7 @@ impl EppoClient {
     fn get_boolean_assignment_details(
         slf: &Bound<EppoClient>,
         flag_key: &str,
-        subject_key: &str,
+        subject_key: ArcStr,
         subject_attributes: Attributes,
         default: Py<PyBool>,
     ) -> PyResult<EvaluationResult> {
@@ -297,7 +297,7 @@ impl EppoClient {
     fn get_json_assignment_details(
         slf: &Bound<EppoClient>,
         flag_key: &str,
-        subject_key: &str,
+        subject_key: ArcStr,
         subject_attributes: Attributes,
         default: Py<PyAny>,
     ) -> PyResult<EvaluationResult> {
@@ -363,23 +363,23 @@ impl EppoClient {
     fn get_bandit_action(
         slf: &Bound<EppoClient>,
         flag_key: &str,
-        subject_key: &str,
+        subject_key: ArcStr,
         #[pyo3(from_py_with = "context_attributes_from_py")] subject_context: RefOrOwned<
             ContextAttributes,
             PyRef<ContextAttributes>,
         >,
         #[pyo3(from_py_with = "actions_from_py")] actions: HashMap<String, ContextAttributes>,
-        default: &str,
+        default: ArcStr,
     ) -> PyResult<EvaluationResult> {
         let py = slf.py();
         let this = slf.get();
 
         let mut result = this.evaluator.get_bandit_action(
             flag_key,
-            &subject_key.into(),
+            &subject_key,
             &subject_context,
             &actions,
-            &default.into(),
+            &default,
         );
 
         if let Some(event) = result.assignment_event.take() {
@@ -396,23 +396,23 @@ impl EppoClient {
     fn get_bandit_action_details(
         slf: &Bound<EppoClient>,
         flag_key: &str,
-        subject_key: &str,
+        subject_key: ArcStr,
         #[pyo3(from_py_with = "context_attributes_from_py")] subject_context: RefOrOwned<
             ContextAttributes,
             PyRef<ContextAttributes>,
         >,
         #[pyo3(from_py_with = "actions_from_py")] actions: HashMap<String, ContextAttributes>,
-        default: &str,
+        default: ArcStr,
     ) -> PyResult<EvaluationResult> {
         let py = slf.py();
         let this = slf.get();
 
         let (mut result, details) = this.evaluator.get_bandit_action_details(
             flag_key,
-            &subject_key.into(),
+            &subject_key,
             &subject_context,
             &actions,
-            &default.into(),
+            &default,
         );
 
         if let Some(event) = result.assignment_event.take() {
@@ -610,7 +610,7 @@ impl EppoClient {
         &self,
         py: Python,
         flag_key: &str,
-        subject_key: &str,
+        subject_key: ArcStr,
         subject_attributes: Attributes,
         expected_type: Option<VariationType>,
         default: Py<PyAny>,
@@ -650,7 +650,7 @@ impl EppoClient {
         &self,
         py: Python,
         flag_key: &str,
-        subject_key: &str,
+        subject_key: ArcStr,
         subject_attributes: Attributes,
         expected_type: Option<VariationType>,
         default: Py<PyAny>,

--- a/python-sdk/src/client.rs
+++ b/python-sdk/src/client.rs
@@ -27,7 +27,7 @@ use eppo_core::{
     poller_thread::{PollerThread, PollerThreadConfig},
     pyo3::TryToPyObject,
     ufc::VariationType,
-    ArcStr, Attributes, ContextAttributes,
+    Attributes, ContextAttributes, Str,
 };
 
 use crate::{
@@ -152,7 +152,7 @@ impl EppoClient {
     fn get_string_assignment(
         slf: &Bound<EppoClient>,
         flag_key: &str,
-        subject_key: ArcStr,
+        subject_key: Str,
         subject_attributes: Attributes,
         default: Py<PyString>,
     ) -> PyResult<PyObject> {
@@ -168,7 +168,7 @@ impl EppoClient {
     fn get_integer_assignment(
         slf: &Bound<EppoClient>,
         flag_key: &str,
-        subject_key: ArcStr,
+        subject_key: Str,
         subject_attributes: Attributes,
         default: Py<PyInt>,
     ) -> PyResult<PyObject> {
@@ -184,7 +184,7 @@ impl EppoClient {
     fn get_numeric_assignment(
         slf: &Bound<EppoClient>,
         flag_key: &str,
-        subject_key: ArcStr,
+        subject_key: Str,
         subject_attributes: Attributes,
         default: Py<PyFloat>,
     ) -> PyResult<PyObject> {
@@ -200,7 +200,7 @@ impl EppoClient {
     fn get_boolean_assignment(
         slf: &Bound<EppoClient>,
         flag_key: &str,
-        subject_key: ArcStr,
+        subject_key: Str,
         subject_attributes: Attributes,
         default: Py<PyBool>,
     ) -> PyResult<PyObject> {
@@ -216,7 +216,7 @@ impl EppoClient {
     fn get_json_assignment(
         slf: &Bound<EppoClient>,
         flag_key: &str,
-        subject_key: ArcStr,
+        subject_key: Str,
         subject_attributes: Attributes,
         default: PyObject,
     ) -> PyResult<PyObject> {
@@ -233,7 +233,7 @@ impl EppoClient {
     fn get_string_assignment_details(
         slf: &Bound<EppoClient>,
         flag_key: &str,
-        subject_key: ArcStr,
+        subject_key: Str,
         subject_attributes: Attributes,
         default: Py<PyString>,
     ) -> PyResult<EvaluationResult> {
@@ -249,7 +249,7 @@ impl EppoClient {
     fn get_integer_assignment_details(
         slf: &Bound<EppoClient>,
         flag_key: &str,
-        subject_key: ArcStr,
+        subject_key: Str,
         subject_attributes: Attributes,
         default: Py<PyInt>,
     ) -> PyResult<EvaluationResult> {
@@ -265,7 +265,7 @@ impl EppoClient {
     fn get_numeric_assignment_details(
         slf: &Bound<EppoClient>,
         flag_key: &str,
-        subject_key: ArcStr,
+        subject_key: Str,
         subject_attributes: Attributes,
         default: Py<PyFloat>,
     ) -> PyResult<EvaluationResult> {
@@ -281,7 +281,7 @@ impl EppoClient {
     fn get_boolean_assignment_details(
         slf: &Bound<EppoClient>,
         flag_key: &str,
-        subject_key: ArcStr,
+        subject_key: Str,
         subject_attributes: Attributes,
         default: Py<PyBool>,
     ) -> PyResult<EvaluationResult> {
@@ -297,7 +297,7 @@ impl EppoClient {
     fn get_json_assignment_details(
         slf: &Bound<EppoClient>,
         flag_key: &str,
-        subject_key: ArcStr,
+        subject_key: Str,
         subject_attributes: Attributes,
         default: Py<PyAny>,
     ) -> PyResult<EvaluationResult> {
@@ -363,13 +363,13 @@ impl EppoClient {
     fn get_bandit_action(
         slf: &Bound<EppoClient>,
         flag_key: &str,
-        subject_key: ArcStr,
+        subject_key: Str,
         #[pyo3(from_py_with = "context_attributes_from_py")] subject_context: RefOrOwned<
             ContextAttributes,
             PyRef<ContextAttributes>,
         >,
         #[pyo3(from_py_with = "actions_from_py")] actions: HashMap<String, ContextAttributes>,
-        default: ArcStr,
+        default: Str,
     ) -> PyResult<EvaluationResult> {
         let py = slf.py();
         let this = slf.get();
@@ -396,13 +396,13 @@ impl EppoClient {
     fn get_bandit_action_details(
         slf: &Bound<EppoClient>,
         flag_key: &str,
-        subject_key: ArcStr,
+        subject_key: Str,
         #[pyo3(from_py_with = "context_attributes_from_py")] subject_context: RefOrOwned<
             ContextAttributes,
             PyRef<ContextAttributes>,
         >,
         #[pyo3(from_py_with = "actions_from_py")] actions: HashMap<String, ContextAttributes>,
-        default: ArcStr,
+        default: Str,
     ) -> PyResult<EvaluationResult> {
         let py = slf.py();
         let this = slf.get();
@@ -610,7 +610,7 @@ impl EppoClient {
         &self,
         py: Python,
         flag_key: &str,
-        subject_key: ArcStr,
+        subject_key: Str,
         subject_attributes: Attributes,
         expected_type: Option<VariationType>,
         default: Py<PyAny>,
@@ -650,7 +650,7 @@ impl EppoClient {
         &self,
         py: Python,
         flag_key: &str,
-        subject_key: ArcStr,
+        subject_key: Str,
         subject_attributes: Attributes,
         expected_type: Option<VariationType>,
         default: Py<PyAny>,

--- a/python-sdk/src/configuration.rs
+++ b/python-sdk/src/configuration.rs
@@ -2,13 +2,11 @@
 // backend to pass on configuration when initializing the frontend.
 use std::{borrow::Cow, sync::Arc};
 
-use pyo3::{
-    exceptions::{PyRuntimeError, PyValueError},
-    prelude::*,
-    types::PySet,
-};
+use pyo3::{exceptions::PyValueError, prelude::*, types::PySet};
 
-use eppo_core::Configuration as CoreConfiguration;
+use eppo_core::{ufc::UniversalFlagConfig, Configuration as CoreConfiguration};
+
+use crate::SDK_METADATA;
 
 /// Eppo configuration of the client, including flags and bandits configuration.
 ///
@@ -23,18 +21,20 @@ impl Configuration {
     #[new]
     #[pyo3(signature = (*, flags_configuration, bandits_configuration = None))]
     fn py_new(
-        flags_configuration: &[u8],
+        flags_configuration: Vec<u8>,
         bandits_configuration: Option<&[u8]>,
     ) -> PyResult<Configuration> {
-        let flag_config = serde_json::from_slice(flags_configuration).map_err(|err| {
-            PyValueError::new_err(format!("argument 'flags_configuration': {err:?}"))
-        })?;
+        let flag_config = UniversalFlagConfig::from_json(SDK_METADATA, flags_configuration)
+            .map_err(|err| {
+                PyValueError::new_err(format!("argument 'flags_configuration': {err:?}"))
+            })?;
         let bandits_config = bandits_configuration
             .map(|it| serde_json::from_slice(it))
             .transpose()
             .map_err(|err| {
                 PyValueError::new_err(format!("argument 'bandits_configuration': {err:?}"))
             })?;
+
         Ok(Configuration {
             configuration: Arc::new(CoreConfiguration::from_server_response(
                 flag_config,
@@ -46,7 +46,7 @@ impl Configuration {
     // Returns a set of all flag keys that have been initialized.
     // This can be useful to debug the initialization process.
     fn get_flag_keys<'py>(&'py self, py: Python<'py>) -> PyResult<Bound<PySet>> {
-        PySet::new_bound(py, self.configuration.flags.flags.keys())
+        PySet::new_bound(py, &self.configuration.flag_keys())
     }
 
     // Returns a set of all bandit keys that have been initialized.
@@ -65,13 +65,8 @@ impl Configuration {
     ///
     /// It should be treated as opaque and passed on to another Eppo client (e.g., javascript client
     /// on frontend) for initialization.
-    fn get_flags_configuration(&self) -> PyResult<Cow<[u8]>> {
-        serde_json::to_vec(&self.configuration.flags)
-            .map(Cow::Owned)
-            .map_err(|err| {
-                log::warn!(target:"eppo", "{err}");
-                PyRuntimeError::new_err(err.to_string())
-            })
+    fn get_flags_configuration(&self) -> Cow<[u8]> {
+        Cow::Borrowed(self.configuration.flags.to_json())
     }
 }
 

--- a/python-sdk/src/lib.rs
+++ b/python-sdk/src/lib.rs
@@ -1,10 +1,17 @@
 use pyo3::prelude::*;
 
+use eppo_core::SdkMetadata;
+
 mod assignment_logger;
 mod client;
 mod client_config;
 mod configuration;
 mod init;
+
+pub(crate) const SDK_METADATA: SdkMetadata = SdkMetadata {
+    name: "python",
+    version: env!("CARGO_PKG_VERSION"),
+};
 
 #[pymodule(module = "eppo_client", name = "_eppo_client")]
 mod eppo_client {

--- a/ruby-sdk/Gemfile.lock
+++ b/ruby-sdk/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    eppo-server-sdk (3.1.0)
+    eppo-server-sdk (3.1.1)
 
 GEM
   remote: https://rubygems.org/

--- a/ruby-sdk/ext/eppo_client/src/client.rs
+++ b/ruby-sdk/ext/eppo_client/src/client.rs
@@ -6,7 +6,7 @@ use eppo_core::{
     eval::{Evaluator, EvaluatorConfig},
     poller_thread::PollerThread,
     ufc::VariationType,
-    ArcStr, Attributes, ContextAttributes, SdkMetadata,
+    Attributes, ContextAttributes, SdkMetadata,
 };
 use magnus::{error::Result, exception, prelude::*, Error, TryConvert, Value};
 
@@ -81,7 +81,7 @@ impl Client {
             .evaluator
             .get_assignment(
                 &flag_key,
-                &Arc::from(subject_key),
+                &subject_key.into(),
                 &Arc::new(subject_attributes),
                 Some(expected_type),
             )
@@ -103,7 +103,7 @@ impl Client {
 
         let result = self.evaluator.get_assignment_details(
             &flag_key,
-            &Arc::from(subject_key),
+            &subject_key.into(),
             &Arc::new(subject_attributes),
             Some(expected_type),
         );
@@ -132,10 +132,10 @@ impl Client {
 
         let result = self.evaluator.get_bandit_action(
             &flag_key,
-            &Arc::from(subject_key),
+            &subject_key.into(),
             &subject_attributes,
             &actions,
-            &ArcStr::from(default_variation),
+            &default_variation.into(),
         );
 
         serde_magnus::serialize(&result)
@@ -162,10 +162,10 @@ impl Client {
 
         let result = self.evaluator.get_bandit_action_details(
             &flag_key,
-            &Arc::from(subject_key.into_boxed_str()),
+            &subject_key.into_boxed_str().into(),
             &subject_attributes,
             &actions,
-            &ArcStr::from(default_variation),
+            &default_variation.into(),
         );
 
         serde_magnus::serialize(&result)

--- a/ruby-sdk/ext/eppo_client/src/client.rs
+++ b/ruby-sdk/ext/eppo_client/src/client.rs
@@ -81,8 +81,8 @@ impl Client {
             .evaluator
             .get_assignment(
                 &flag_key,
-                &subject_key,
-                &subject_attributes,
+                &Arc::from(subject_key),
+                &Arc::new(subject_attributes),
                 Some(expected_type),
             )
             // TODO: maybe expose possible errors individually.
@@ -103,8 +103,8 @@ impl Client {
 
         let result = self.evaluator.get_assignment_details(
             &flag_key,
-            &subject_key,
-            &subject_attributes,
+            &Arc::from(subject_key),
+            &Arc::new(subject_attributes),
             Some(expected_type),
         );
 
@@ -132,7 +132,7 @@ impl Client {
 
         let result = self.evaluator.get_bandit_action(
             &flag_key,
-            &subject_key,
+            &Arc::from(subject_key),
             &subject_attributes,
             &actions,
             &default_variation,
@@ -162,7 +162,7 @@ impl Client {
 
         let result = self.evaluator.get_bandit_action_details(
             &flag_key,
-            &subject_key,
+            &Arc::from(subject_key.into_boxed_str()),
             &subject_attributes,
             &actions,
             &default_variation,

--- a/ruby-sdk/ext/eppo_client/src/client.rs
+++ b/ruby-sdk/ext/eppo_client/src/client.rs
@@ -6,7 +6,7 @@ use eppo_core::{
     eval::{Evaluator, EvaluatorConfig},
     poller_thread::PollerThread,
     ufc::VariationType,
-    Attributes, ContextAttributes, SdkMetadata,
+    ArcStr, Attributes, ContextAttributes, SdkMetadata,
 };
 use magnus::{error::Result, exception, prelude::*, Error, TryConvert, Value};
 
@@ -135,7 +135,7 @@ impl Client {
             &Arc::from(subject_key),
             &subject_attributes,
             &actions,
-            &default_variation,
+            &ArcStr::from(default_variation),
         );
 
         serde_magnus::serialize(&result)
@@ -165,7 +165,7 @@ impl Client {
             &Arc::from(subject_key.into_boxed_str()),
             &subject_attributes,
             &actions,
-            &default_variation,
+            &ArcStr::from(default_variation),
         );
 
         serde_magnus::serialize(&result)

--- a/ruby-sdk/ext/eppo_client/src/client.rs
+++ b/ruby-sdk/ext/eppo_client/src/client.rs
@@ -162,7 +162,7 @@ impl Client {
 
         let result = self.evaluator.get_bandit_action_details(
             &flag_key,
-            &subject_key.into_boxed_str().into(),
+            &subject_key.into(),
             &subject_attributes,
             &actions,
             &default_variation.into(),

--- a/rust-sdk/examples/assignment_details/main.rs
+++ b/rust-sdk/examples/assignment_details/main.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use eppo::AttributeValue;
 
 pub fn main() -> eppo::Result<()> {
@@ -24,8 +26,8 @@ pub fn main() -> eppo::Result<()> {
     // Get assignment for test-subject.
     let assignment_with_details = client.get_boolean_assignment_details(
         "a-boolean-flag",
-        "test-subject",
-        &[("name".to_owned(), AttributeValue::from("<your name>"))].into(),
+        &"test-subject".into(),
+        &Arc::new([("name".to_owned(), AttributeValue::from("<your name>"))].into()),
     );
 
     println!(

--- a/rust-sdk/examples/simple/main.rs
+++ b/rust-sdk/examples/simple/main.rs
@@ -23,7 +23,11 @@ pub fn main() -> eppo::Result<()> {
 
     // Get assignment for test-subject.
     let assignment = client
-        .get_boolean_assignment("a-boolean-flag", "test-subject", &HashMap::new())
+        .get_boolean_assignment(
+            "a-boolean-flag",
+            &"test-subject".into(),
+            &HashMap::new().into(),
+        )
         .unwrap_or_default()
         // default assignment
         .unwrap_or(false);

--- a/rust-sdk/src/assignment_logger.rs
+++ b/rust-sdk/src/assignment_logger.rs
@@ -11,7 +11,7 @@ pub trait AssignmentLogger {
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```no_run
     /// # use eppo::{AssignmentLogger, AssignmentEvent};
     /// struct MyAssignmentLogger;
     ///

--- a/rust-sdk/src/client.rs
+++ b/rust-sdk/src/client.rs
@@ -312,7 +312,7 @@ impl<'a> Client<'a> {
     ///         ("language".into(), "en".into())
     ///     ].into_iter().collect()))
     ///     .unwrap_or_default()
-    ///     .unwrap_or(json!({}));
+    ///     .unwrap_or(json!({}).into());
     /// # }
     /// ```
     pub fn get_json_assignment(
@@ -320,7 +320,7 @@ impl<'a> Client<'a> {
         flag_key: &str,
         subject_key: &ArcStr,
         subject_attributes: &Arc<Attributes>,
-    ) -> Result<Option<serde_json::Value>, EvaluationError> {
+    ) -> Result<Option<Arc<serde_json::Value>>, EvaluationError> {
         self.get_assignment_inner(
             flag_key,
             subject_key,
@@ -493,7 +493,7 @@ impl<'a> Client<'a> {
         flag_key: &str,
         subject_key: &ArcStr,
         subject_attributes: &Arc<Attributes>,
-    ) -> EvaluationResultWithDetails<serde_json::Value> {
+    ) -> EvaluationResultWithDetails<Arc<serde_json::Value>> {
         self.get_assignment_details_inner(
             flag_key,
             subject_key,

--- a/rust-sdk/src/client.rs
+++ b/rust-sdk/src/client.rs
@@ -139,7 +139,7 @@ impl<'a> Client<'a> {
     ///         ("language".into(), "en".into())
     ///     ].into_iter().collect()))
     ///     .unwrap_or_default()
-    ///     .unwrap_or("default_value".to_owned());
+    ///     .unwrap_or("default_value".into());
     /// # }
     /// ```
     pub fn get_string_assignment(
@@ -147,7 +147,7 @@ impl<'a> Client<'a> {
         flag_key: &str,
         subject_key: &ArcStr,
         subject_attributes: &Arc<Attributes>,
-    ) -> Result<Option<String>, EvaluationError> {
+    ) -> Result<Option<ArcStr>, EvaluationError> {
         self.get_assignment_inner(
             flag_key,
             subject_key,
@@ -401,7 +401,7 @@ impl<'a> Client<'a> {
         flag_key: &str,
         subject_key: &ArcStr,
         subject_attributes: &Arc<Attributes>,
-    ) -> EvaluationResultWithDetails<String> {
+    ) -> EvaluationResultWithDetails<ArcStr> {
         self.get_assignment_details_inner(
             flag_key,
             subject_key,

--- a/rust-sdk/src/client.rs
+++ b/rust-sdk/src/client.rs
@@ -574,31 +574,31 @@ mod tests {
             UniversalFlagConfig {
                 created_at: chrono::Utc::now(),
                 environment: Environment {
-                    name: "test".to_owned(),
+                    name: "test".into(),
                 },
                 flags: [(
                     "flag".to_owned(),
                     TryParse::Parsed(Flag {
-                        key: "flag".to_owned(),
+                        key: "flag".into(),
                         enabled: true,
                         variation_type: VariationType::Boolean,
                         variations: [(
                             "variation".to_owned(),
                             Variation {
-                                key: "variation".to_owned(),
+                                key: "variation".into(),
                                 value: true.into(),
                             },
                         )]
                         .into(),
                         allocations: vec![Allocation {
-                            key: "allocation".to_owned(),
+                            key: "allocation".into(),
                             rules: vec![],
                             start_at: None,
                             end_at: None,
                             splits: vec![Split {
                                 shards: vec![],
                                 variation_key: "variation".to_owned(),
-                                extra_logging: HashMap::new(),
+                                extra_logging: Arc::new(HashMap::new()),
                             }],
                             do_log: false,
                         }],

--- a/rust-sdk/src/client.rs
+++ b/rust-sdk/src/client.rs
@@ -10,7 +10,7 @@ use eppo_core::{
     configuration_store::ConfigurationStore,
     eval::{Evaluator, EvaluatorConfig},
     ufc::{Assignment, VariationType},
-    ArcStr,
+    Str,
 };
 
 /// A client for Eppo API.
@@ -112,7 +112,7 @@ impl<'a> Client<'a> {
     pub fn get_assignment(
         &self,
         flag_key: &str,
-        subject_key: &ArcStr,
+        subject_key: &Str,
         subject_attributes: &Arc<Attributes>,
     ) -> Result<Option<AssignmentValue>, EvaluationError> {
         self.get_assignment_inner(flag_key, subject_key, subject_attributes, None, |x| x)
@@ -145,9 +145,9 @@ impl<'a> Client<'a> {
     pub fn get_string_assignment(
         &self,
         flag_key: &str,
-        subject_key: &ArcStr,
+        subject_key: &Str,
         subject_attributes: &Arc<Attributes>,
-    ) -> Result<Option<ArcStr>, EvaluationError> {
+    ) -> Result<Option<Str>, EvaluationError> {
         self.get_assignment_inner(
             flag_key,
             subject_key,
@@ -188,7 +188,7 @@ impl<'a> Client<'a> {
     pub fn get_integer_assignment(
         &self,
         flag_key: &str,
-        subject_key: &ArcStr,
+        subject_key: &Str,
         subject_attributes: &Arc<Attributes>,
     ) -> Result<Option<i64>, EvaluationError> {
         self.get_assignment_inner(
@@ -231,7 +231,7 @@ impl<'a> Client<'a> {
     pub fn get_numeric_assignment(
         &self,
         flag_key: &str,
-        subject_key: &ArcStr,
+        subject_key: &Str,
         subject_attributes: &Arc<Attributes>,
     ) -> Result<Option<f64>, EvaluationError> {
         self.get_assignment_inner(
@@ -274,7 +274,7 @@ impl<'a> Client<'a> {
     pub fn get_boolean_assignment(
         &self,
         flag_key: &str,
-        subject_key: &ArcStr,
+        subject_key: &Str,
         subject_attributes: &Arc<Attributes>,
     ) -> Result<Option<bool>, EvaluationError> {
         self.get_assignment_inner(
@@ -318,7 +318,7 @@ impl<'a> Client<'a> {
     pub fn get_json_assignment(
         &self,
         flag_key: &str,
-        subject_key: &ArcStr,
+        subject_key: &Str,
         subject_attributes: &Arc<Attributes>,
     ) -> Result<Option<Arc<serde_json::Value>>, EvaluationError> {
         self.get_assignment_inner(
@@ -337,7 +337,7 @@ impl<'a> Client<'a> {
     fn get_assignment_inner<T>(
         &self,
         flag_key: &str,
-        subject_key: &ArcStr,
+        subject_key: &Str,
         subject_attributes: &Arc<Attributes>,
         expected_type: Option<VariationType>,
         convert: impl FnOnce(AssignmentValue) -> T,
@@ -385,7 +385,7 @@ impl<'a> Client<'a> {
     pub fn get_assignment_details(
         &self,
         flag_key: &str,
-        subject_key: &ArcStr,
+        subject_key: &Str,
         subject_attributes: &Arc<Attributes>,
     ) -> EvaluationResultWithDetails<AssignmentValue> {
         self.get_assignment_details_inner(flag_key, subject_key, subject_attributes, None)
@@ -399,9 +399,9 @@ impl<'a> Client<'a> {
     pub fn get_string_assignment_details(
         &self,
         flag_key: &str,
-        subject_key: &ArcStr,
+        subject_key: &Str,
         subject_attributes: &Arc<Attributes>,
-    ) -> EvaluationResultWithDetails<ArcStr> {
+    ) -> EvaluationResultWithDetails<Str> {
         self.get_assignment_details_inner(
             flag_key,
             subject_key,
@@ -422,7 +422,7 @@ impl<'a> Client<'a> {
     pub fn get_integer_assignment_details(
         &self,
         flag_key: &str,
-        subject_key: &ArcStr,
+        subject_key: &Str,
         subject_attributes: &Arc<Attributes>,
     ) -> EvaluationResultWithDetails<i64> {
         self.get_assignment_details_inner(
@@ -445,7 +445,7 @@ impl<'a> Client<'a> {
     pub fn get_numeric_assignment_details(
         &self,
         flag_key: &str,
-        subject_key: &ArcStr,
+        subject_key: &Str,
         subject_attributes: &Arc<Attributes>,
     ) -> EvaluationResultWithDetails<f64> {
         self.get_assignment_details_inner(
@@ -468,7 +468,7 @@ impl<'a> Client<'a> {
     pub fn get_boolean_assignment_details(
         &self,
         flag_key: &str,
-        subject_key: &ArcStr,
+        subject_key: &Str,
         subject_attributes: &Arc<Attributes>,
     ) -> EvaluationResultWithDetails<bool> {
         self.get_assignment_details_inner(
@@ -491,7 +491,7 @@ impl<'a> Client<'a> {
     pub fn get_json_assignment_details(
         &self,
         flag_key: &str,
-        subject_key: &ArcStr,
+        subject_key: &Str,
         subject_attributes: &Arc<Attributes>,
     ) -> EvaluationResultWithDetails<Arc<serde_json::Value>> {
         self.get_assignment_details_inner(
@@ -509,7 +509,7 @@ impl<'a> Client<'a> {
     fn get_assignment_details_inner(
         &self,
         flag_key: &str,
-        subject_key: &ArcStr,
+        subject_key: &Str,
         subject_attributes: &Arc<Attributes>,
         expected_type: Option<VariationType>,
     ) -> EvaluationResultWithDetails<AssignmentValue> {

--- a/rust-sdk/src/client.rs
+++ b/rust-sdk/src/client.rs
@@ -10,6 +10,7 @@ use eppo_core::{
     configuration_store::ConfigurationStore,
     eval::{Evaluator, EvaluatorConfig},
     ufc::{Assignment, VariationType},
+    ArcStr,
 };
 
 /// A client for Eppo API.
@@ -108,8 +109,8 @@ impl<'a> Client<'a> {
     pub fn get_assignment(
         &self,
         flag_key: &str,
-        subject_key: &str,
-        subject_attributes: &Attributes,
+        subject_key: &ArcStr,
+        subject_attributes: &Arc<Attributes>,
     ) -> Result<Option<AssignmentValue>, EvaluationError> {
         self.get_assignment_inner(flag_key, subject_key, subject_attributes, None, |x| x)
     }
@@ -140,8 +141,8 @@ impl<'a> Client<'a> {
     pub fn get_string_assignment(
         &self,
         flag_key: &str,
-        subject_key: &str,
-        subject_attributes: &Attributes,
+        subject_key: &ArcStr,
+        subject_attributes: &Arc<Attributes>,
     ) -> Result<Option<String>, EvaluationError> {
         self.get_assignment_inner(
             flag_key,
@@ -182,8 +183,8 @@ impl<'a> Client<'a> {
     pub fn get_integer_assignment(
         &self,
         flag_key: &str,
-        subject_key: &str,
-        subject_attributes: &Attributes,
+        subject_key: &ArcStr,
+        subject_attributes: &Arc<Attributes>,
     ) -> Result<Option<i64>, EvaluationError> {
         self.get_assignment_inner(
             flag_key,
@@ -224,8 +225,8 @@ impl<'a> Client<'a> {
     pub fn get_numeric_assignment(
         &self,
         flag_key: &str,
-        subject_key: &str,
-        subject_attributes: &Attributes,
+        subject_key: &ArcStr,
+        subject_attributes: &Arc<Attributes>,
     ) -> Result<Option<f64>, EvaluationError> {
         self.get_assignment_inner(
             flag_key,
@@ -266,8 +267,8 @@ impl<'a> Client<'a> {
     pub fn get_boolean_assignment(
         &self,
         flag_key: &str,
-        subject_key: &str,
-        subject_attributes: &Attributes,
+        subject_key: &ArcStr,
+        subject_attributes: &Arc<Attributes>,
     ) -> Result<Option<bool>, EvaluationError> {
         self.get_assignment_inner(
             flag_key,
@@ -309,8 +310,8 @@ impl<'a> Client<'a> {
     pub fn get_json_assignment(
         &self,
         flag_key: &str,
-        subject_key: &str,
-        subject_attributes: &Attributes,
+        subject_key: &ArcStr,
+        subject_attributes: &Arc<Attributes>,
     ) -> Result<Option<serde_json::Value>, EvaluationError> {
         self.get_assignment_inner(
             flag_key,
@@ -328,8 +329,8 @@ impl<'a> Client<'a> {
     fn get_assignment_inner<T>(
         &self,
         flag_key: &str,
-        subject_key: &str,
-        subject_attributes: &Attributes,
+        subject_key: &ArcStr,
+        subject_attributes: &Arc<Attributes>,
         expected_type: Option<VariationType>,
         convert: impl FnOnce(AssignmentValue) -> T,
     ) -> Result<Option<T>, EvaluationError> {
@@ -376,8 +377,8 @@ impl<'a> Client<'a> {
     pub fn get_assignment_details(
         &self,
         flag_key: &str,
-        subject_key: &str,
-        subject_attributes: &Attributes,
+        subject_key: &ArcStr,
+        subject_attributes: &Arc<Attributes>,
     ) -> EvaluationResultWithDetails<AssignmentValue> {
         self.get_assignment_details_inner(flag_key, subject_key, subject_attributes, None)
     }
@@ -390,8 +391,8 @@ impl<'a> Client<'a> {
     pub fn get_string_assignment_details(
         &self,
         flag_key: &str,
-        subject_key: &str,
-        subject_attributes: &Attributes,
+        subject_key: &ArcStr,
+        subject_attributes: &Arc<Attributes>,
     ) -> EvaluationResultWithDetails<String> {
         self.get_assignment_details_inner(
             flag_key,
@@ -413,8 +414,8 @@ impl<'a> Client<'a> {
     pub fn get_integer_assignment_details(
         &self,
         flag_key: &str,
-        subject_key: &str,
-        subject_attributes: &Attributes,
+        subject_key: &ArcStr,
+        subject_attributes: &Arc<Attributes>,
     ) -> EvaluationResultWithDetails<i64> {
         self.get_assignment_details_inner(
             flag_key,
@@ -436,8 +437,8 @@ impl<'a> Client<'a> {
     pub fn get_numeric_assignment_details(
         &self,
         flag_key: &str,
-        subject_key: &str,
-        subject_attributes: &Attributes,
+        subject_key: &ArcStr,
+        subject_attributes: &Arc<Attributes>,
     ) -> EvaluationResultWithDetails<f64> {
         self.get_assignment_details_inner(
             flag_key,
@@ -459,8 +460,8 @@ impl<'a> Client<'a> {
     pub fn get_boolean_assignment_details(
         &self,
         flag_key: &str,
-        subject_key: &str,
-        subject_attributes: &Attributes,
+        subject_key: &ArcStr,
+        subject_attributes: &Arc<Attributes>,
     ) -> EvaluationResultWithDetails<bool> {
         self.get_assignment_details_inner(
             flag_key,
@@ -482,8 +483,8 @@ impl<'a> Client<'a> {
     pub fn get_json_assignment_details(
         &self,
         flag_key: &str,
-        subject_key: &str,
-        subject_attributes: &Attributes,
+        subject_key: &ArcStr,
+        subject_attributes: &Arc<Attributes>,
     ) -> EvaluationResultWithDetails<serde_json::Value> {
         self.get_assignment_details_inner(
             flag_key,
@@ -500,8 +501,8 @@ impl<'a> Client<'a> {
     fn get_assignment_details_inner(
         &self,
         flag_key: &str,
-        subject_key: &str,
-        subject_attributes: &Attributes,
+        subject_key: &ArcStr,
+        subject_attributes: &Arc<Attributes>,
         expected_type: Option<VariationType>,
     ) -> EvaluationResultWithDetails<AssignmentValue> {
         let (result, event) = self.evaluator.get_assignment_details(
@@ -555,7 +556,7 @@ mod tests {
 
         assert_eq!(
             client
-                .get_assignment("flag", "subject", &HashMap::new())
+                .get_assignment("flag", &"subject".into(), &Arc::new(HashMap::new()))
                 .unwrap(),
             None
         );
@@ -613,7 +614,7 @@ mod tests {
 
         assert_eq!(
             client
-                .get_assignment("flag", "subject", &HashMap::new())
+                .get_assignment("flag", &"subject".into(), &Arc::new(HashMap::new()))
                 .unwrap(),
             Some(AssignmentValue::Boolean(true))
         );


### PR DESCRIPTION
This PR minimizes copying that happens inside SDK. This is mostly done by using `Arc` (atomic reference counted pointer).

For strings, I used `Arc<str>` initially. However, I looked through a ton of crates and found one that is optimized for our use case (cheap cloning) — [faststr](https://docs.rs/faststr). In addition to allowing `Arc<str>`, it tries to minimize allocation when converting to/from string type and supports small string optimization (embedding strings up to 24 bytes inside the value itself, without memory allocation). I have benchmarked it and it gives even better results.

Another big realization is that most of `AssignmentEvent` object is static for the same split, so we can pre-compute events beforehand, so we don't move tons of strings around. After we select a split, we can directly get a pair of (assignment value, event).

I also ported JSON precomputing that we implemented in Go SDK (which gives a 5x boost on our json assignment microbenchmark).

As part of implementing pre-computing, I also realized that we can pre-hash salt values, so this gives a small boost for sharding.

The combined effect is a 2.5–4x boost (even on non-logging assignments). Assignment details are having a modest 20% boost.

Python in particular is enjoying these changes (I assume due to decreased allocation on Python/Rust boundary):
```
+----------------------------------+--------------+-----------------------+
| Benchmark                        | 4.0.0-before | 4.0.0-after           |
+==================================+==============+=======================+
| Evaluation                       | 11.5 us      | 2.85 us: 4.05x faster |
+----------------------------------+--------------+-----------------------+
| Evaluation (new-user-onboarding) | 2.96 us      | 261 ns: 11.31x faster |
+----------------------------------+--------------+-----------------------+
| Evaluation (numeric-one-of)      | 5.87 us      | 735 ns: 7.99x faster  |
+----------------------------------+--------------+-----------------------+
| Evaluation (regex-flag)          | 5.09 us      | 504 ns: 10.10x faster |
+----------------------------------+--------------+-----------------------+
| Geometric mean                   | (ref)        | 7.79x faster          |
+----------------------------------+--------------+-----------------------+
```