### PR TITLE
chore: clarify release process

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -13,9 +13,8 @@ on:
   push:
     branches:
       - main
-      - master
-    tags:
-      - '*'
+    release:
+      types: [published]
   pull_request:
   workflow_dispatch:
 

--- a/README.md
+++ b/README.md
@@ -4,3 +4,22 @@
 
 1. Install [rustup](https://rustup.rs/).
 2. Install Ruby using your preferred package manager.
+
+### Release process
+
+To release a new version of SDK:
+1. Make sure that version strings have been updated:
+   - Eppo core: [eppo_core/Cargo.toml](eppo_core/Cargo.toml)
+   - Rust: [rust-sdk/Cargo.toml](rust-sdk/Cargo.toml)
+   - Python: [python-sdk/Cargo.toml](python-sdk/Cargo.toml)
+   - Ruby: [ruby-sdk/lib/eppo_client/version.rb](ruby-sdk/lib/eppo_client/version.rb) and [ruby-sdk/ext/eppo_client/Cargo.toml](ruby-sdk/ext/eppo_client/Cargo.toml)
+2. If SDK depends on a new version of `eppo_core`, the core should be released first.
+3. [Create a new release](https://github.com/Eppo-exp/rust-sdk/releases/new) in GitHub interface.
+   - For tag, use one of the following formats (choose "create new tag on publish"):
+     - `eppo_core@x.y.z`
+     - `rust-sdk@x.y.z`
+     - `python-sdk@x.y.z`
+     - `ruby-sdk@x.y.z`
+   - For generating release notes, select previous tag from the same SDK (e.g., when releasing `python-sdk@4.0.3`, the previous tag should be `python-sdk@4.0.2`). Auto-generate release notes, prune entries that are not relevant for the SDK (e.g., Python SDK release should not list PRs for Ruby).
+   - Publish release.
+   - CI will automatically push a new release out to package registries.


### PR DESCRIPTION
We had a small incident with `python-sdk@4.0.2` tag pushed without updating the version strings so it tried to publish new artifacts into already released `python-sdk@4.0.1` on pypi. Luckily, none of artifacts were actually pushed because they already exist.

This incident went somewhat unnoticed because there were no GitHub release, just a tag. So I only noticed this when trying to push a new release and found that the tag already exists.

I have rectified this by deleting the old `python-sdk@4.0.2` tag that did not have effect and created a proper release.

This PR is a follow-up and:
- Modifies Python workflow to require a GitHub release, so releases are more visible.
- Adds documentation on the release process.