### PR TITLE
chore(core): add "vendored" feature flag to eppo_core

### DIFF
--- a/eppo_core/Cargo.toml
+++ b/eppo_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "eppo_core"
-version = "4.0.0"
+version = "4.1.0"
 edition = "2021"
 description = "Eppo SDK core library"
 repository = "https://github.com/Eppo-exp/rust-sdk"
@@ -12,6 +12,11 @@ rust-version = "1.71.1"
 [features]
 # Add implementation of `FromPyObject`/`ToPyObject` for some types.
 pyo3 = ["dep:pyo3", "dep:serde-pyobject"]
+# Vendor any external libraries that we need (OpenSSL on Linux), so we
+# don’t depend on shared libraries.
+#
+# See: https://github.com/PyO3/maturin-action/discussions/78
+vendored = ["reqwest/native-tls-vendored"]
 
 [dependencies]
 chrono = { version = "0.4.38", features = ["serde"] }
@@ -31,6 +36,19 @@ url = "2.5.0"
 # pyo3 dependencies
 pyo3 = { version = "0.22.0", optional = true, default-features = false }
 serde-pyobject = { version = "0.4.0", optional = true}
+
+# vendored dependencies
+[target.'cfg(all(target_os = "linux", target_arch = "s390x"))'.dependencies]
+# OpenSSL 3.3+ includes a patch[1] for s390x architecture that uses a
+# specialized instruction (cijne), which is not recognized by GCC in
+# ghcr.io/rust-cross/manylinux2014-cross:s390x, and thus fails to
+# compile in CI.
+#
+# Pin "openssl-src" to 300.2.x, which will install openssl-3.2.x,
+# which didn't use cijne.
+#
+# [1]: https://github.com/openssl/openssl/pull/22221
+openssl-src = { version = "~300.2", optional = true }
 
 [dev-dependencies]
 criterion = { version = "0.4", features = ["html_reports"] }

--- a/python-sdk/Cargo.toml
+++ b/python-sdk/Cargo.toml
@@ -8,29 +8,9 @@ publish = false
 crate-type = ["cdylib"]
 
 [dependencies]
-eppo_core = { version = "4.0.0", path = "../eppo_core", features = ["pyo3"] }
+eppo_core = { version = "4.1.0", path = "../eppo_core", features = ["pyo3", "vendored"] }
 log = "0.4.22"
 pyo3 = { version = "0.22.0" }
 pyo3-log = "0.11.0"
 serde-pyobject = "0.4.0"
 serde_json = "1.0.125"
-
-[target.'cfg(target_os = "linux")'.dependencies]
-# We don't use reqwest directly, so the following overrides it to
-# enable feature flag. native-tls-vendored is required to vendor
-# OpenSSL on linux builds, so we don't depend on shared libraries.
-#
-# See: https://github.com/PyO3/maturin-action/discussions/78
-reqwest = { version = "*", features = ["native-tls-vendored"] }
-
-[target.'cfg(all(target_os = "linux", target_arch = "s390x"))'.dependencies]
-# OpenSSL 3.3+ includes a patch[1] for s390x architecture that uses a
-# specialized instruction (cijne), which is not recognized by GCC in
-# ghcr.io/rust-cross/manylinux2014-cross:s390x, and thus fails to
-# compile in CI.
-#
-# Pin "openssl-src" to 300.2.x, which will install openssl-3.2.x,
-# which didn't use cijne.
-#
-# [1]: https://github.com/openssl/openssl/pull/22221
-openssl-src = "~300.2"

--- a/ruby-sdk/ext/eppo_client/Cargo.toml
+++ b/ruby-sdk/ext/eppo_client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "eppo_client"
 # TODO: this version and lib/eppo_client/version.rb should be in sync
-version = "3.2.0"
+version = "3.2.1"
 edition = "2021"
 license = "MIT"
 publish = false
@@ -12,7 +12,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 env_logger = { version = "0.11.3", features = ["unstable-kv"] }
-eppo_core = { version = "4.0.0" }
+eppo_core = { version = "4.1.0", features = ["vendored"] }
 log = { version = "0.4.21", features = ["kv_serde"] }
 magnus = { version = "0.6.4" }
 serde = { version = "1.0.203", features = ["derive"] }

--- a/ruby-sdk/lib/eppo_client/version.rb
+++ b/ruby-sdk/lib/eppo_client/version.rb
@@ -2,5 +2,5 @@
 
 # TODO: this version and ext/eppo_client/Cargo.toml should be in sync
 module EppoClient
-  VERSION = "3.2.0"
+  VERSION = "3.2.1"
 end

--- a/rust-sdk/Cargo.toml
+++ b/rust-sdk/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["config"]
 rust-version = "1.71.1"
 
 [dependencies]
-eppo_core = { version = "4.0.0", path = "../eppo_core" }
+eppo_core = { version = "4.1.0", path = "../eppo_core" }
 log = { version = "0.4.21", features = ["kv", "kv_serde"] }
 serde_json = "1.0.116"
 


### PR DESCRIPTION
Add "vendored" feature flag to eppo_core, which we’re going to reuse in #42.