### PR TITLE
chore(python): fix release workflow trigger

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -13,8 +13,8 @@ on:
   push:
     branches:
       - main
-    release:
-      types: [published]
+  release:
+    types: [published]
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
`release` was accidentally nested under `push`, so release of `python-sdk@4.0.3` didn't go through.