### PR TITLE
fix: Missing ruby files from native gems

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -174,6 +174,14 @@ jobs:
             --build \
             -- ${{ matrix._.rb-sys-dock-setup }}
 
+      - name: Smoke gem install
+        if: matrix.ruby-platform == 'x86_64-linux' # GitHub actions architecture
+        run: |
+          gem install pkg/eppo-server-sdk-*.gem --verbose
+          script="puts EppoClient::Core::Client.new(EppoClient::Config.new('placeholder'))"
+          ruby -reppo_client -e "$script" | grep fetching new configuration
+          echo "✅ Successfully installed gem"
+
       - name: Set outputs
         id: set-outputs
         shell: bash

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@
 *.pdb
 
 node_modules
+
+.idea/

--- a/ruby-sdk/Gemfile.lock
+++ b/ruby-sdk/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    eppo-server-sdk (3.2.1)
+    eppo-server-sdk (3.2.2)
 
 GEM
   remote: https://rubygems.org/

--- a/ruby-sdk/Gemfile.lock
+++ b/ruby-sdk/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     eppo-server-sdk (3.2.2)
+      rb_sys (~> 0.9.102)
 
 GEM
   remote: https://rubygems.org/

--- a/ruby-sdk/eppo-server-sdk.gemspec
+++ b/ruby-sdk/eppo-server-sdk.gemspec
@@ -24,22 +24,15 @@ Gem::Specification.new do |spec|
     "wiki_uri" => "https://github.com/Eppo-exp/ruby-sdk/wiki"
   }
 
-  # Specify which files should be added to the gem when it is released.
-  # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
-  gemspec = File.basename(__FILE__)
-  spec.files = IO.popen(%w[git ls-files -z], chdir: __dir__, err: IO::NULL) do |ls|
-    ls.readlines("\x0", chomp: true).reject do |f|
-      (f == gemspec) ||
-        f.start_with?(*%w[bin/ test/ spec/ features/ .cargo/ .git/ .github/ appveyor Gemfile])
-    end
-  end
+  spec.files = Dir["{lib,ext}/**/*", "LICENSE", "README.md", "Cargo.*"]
+  spec.files.reject! { |f| File.directory?(f) }
+  spec.files.reject! { |f| f =~ /\.(dll|so|dylib|lib|bundle)\Z/ }
   spec.bindir = "exe"
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
-  spec.extensions = ["ext/eppo_client/Cargo.toml"]
+  spec.extensions = ["ext/eppo_client/extconf.rb"]
 
-  # Uncomment to register a new dependency of your gem
-  # spec.add_dependency "example-gem", "~> 1.0"
+  spec.add_dependency "rb_sys", "~> 0.9.102"
 
   # For more information and examples about making a new gem, check out our
   # guide at: https://bundler.io/guides/creating_gem.html

--- a/ruby-sdk/ext/eppo_client/Cargo.toml
+++ b/ruby-sdk/ext/eppo_client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "eppo_client"
 # TODO: this version and lib/eppo_client/version.rb should be in sync
-version = "3.2.2"
+version = "3.2.3"
 edition = "2021"
 license = "MIT"
 publish = false

--- a/ruby-sdk/lib/eppo_client/version.rb
+++ b/ruby-sdk/lib/eppo_client/version.rb
@@ -2,5 +2,5 @@
 
 # TODO: this version and ext/eppo_client/Cargo.toml should be in sync
 module EppoClient
-  VERSION = "3.2.2"
+  VERSION = "3.2.3"
 end


### PR DESCRIPTION
## Description

Add mising ruby files to gemspec. Since we build the cross platform gems using `rb-sys-dock`, I think `git ls-files` doesn't work because the `.git` directory is not available from the docker container.

Reference: wasmtime gemspec: https://github.com/bytecodealliance/wasmtime-rb/blob/main/wasmtime.gemspec#L21-L28

## Testing

```
gem install --local pkg/eppo-server-sdk-3.2.2-arm64-darwin.gem
ruby -reppo_client -e "puts EppoClient::VERSION" # => 3.2.2
```