### PR TITLE
fix(ruby): Require shared lib from correct subdir

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -175,7 +175,7 @@ jobs:
             -- ${{ matrix._.rb-sys-dock-setup }}
 
       - name: Smoke gem install
-        if: matrix.ruby-platform == 'x86_64-linux' # GitHub actions architecture
+        if: matrix._.platform == 'x86_64-linux' # GitHub actions architecture
         run: |
           gem install pkg/eppo-server-sdk-*.gem --verbose
           script="puts EppoClient::Core::Client.new(EppoClient::Config.new('placeholder'))"

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@
 node_modules
 
 .idea/
+.DS_Store

--- a/ruby-sdk/Cargo.lock
+++ b/ruby-sdk/Cargo.lock
@@ -304,7 +304,7 @@ dependencies = [
 
 [[package]]
 name = "eppo_client"
-version = "3.2.4"
+version = "3.2.5"
 dependencies = [
  "env_logger",
  "eppo_core",

--- a/ruby-sdk/Gemfile.lock
+++ b/ruby-sdk/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    eppo-server-sdk (3.2.4)
+    eppo-server-sdk (3.2.5)
       rb_sys (~> 0.9.102)
 
 GEM

--- a/ruby-sdk/README.md
+++ b/ruby-sdk/README.md
@@ -23,5 +23,6 @@ Make sure you remove the override before updating `Cargo.lock`. Otherwise, the l
 
 ## Releasing
 
-* Bump versions in `ruby-sdk/lib/eppo_client/version.rb` and `ruby-sdk/ext/eppo_client/Cargo.toml`.
-* Run `cargo update --workspace --verbose` to update `Cargo.lock` and `Gemfile.lock`.
+* Bump versions in `ruby-sdk/lib/eppo_client/version.rb` and `ruby-sdk/ext/eppo_client/Cargo.toml`
+* Run `cargo update --workspace --verbose` to update `Cargo.lock`
+* Run `bundle` to update `Gemfile.lock`

--- a/ruby-sdk/ext/eppo_client/Cargo.toml
+++ b/ruby-sdk/ext/eppo_client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "eppo_client"
 # TODO: this version and lib/eppo_client/version.rb should be in sync
-version = "3.2.4"
+version = "3.2.5"
 edition = "2021"
 license = "MIT"
 publish = false

--- a/ruby-sdk/lib/eppo_client/client.rb
+++ b/ruby-sdk/lib/eppo_client/client.rb
@@ -4,7 +4,14 @@ require "singleton"
 require "logger"
 
 require_relative "config"
-require_relative "eppo_client"
+
+# Tries to require the extension for the current Ruby version first
+begin
+  RUBY_VERSION =~ /(\d+\.\d+)/
+  require_relative "#{Regexp.last_match(1)}/eppo_client"
+rescue LoadError
+  require_relative "eppo_client"
+end
 
 module EppoClient
   # The main client singleton
@@ -15,7 +22,7 @@ module EppoClient
     def init(config)
       config.validate
 
-      if !@core.nil? then
+      if !@core.nil?
         STDERR.puts "Eppo Warning: multiple initialization of the client"
         @core.shutdown
       end

--- a/ruby-sdk/lib/eppo_client/version.rb
+++ b/ruby-sdk/lib/eppo_client/version.rb
@@ -2,5 +2,5 @@
 
 # TODO: this version and ext/eppo_client/Cargo.toml should be in sync
 module EppoClient
-  VERSION = "3.2.4"
+  VERSION = "3.2.5"
 end


### PR DESCRIPTION
rake-compiler puts the shared lib in a subdirectory of `eppo_client` when we build with multiple ruby target versions, so we need to load the lib from the correct subdir.

Again, shamelessly stolen from wasmtime.

Also fixed the CI step so it runs properly (it wasnt)