### PR TITLE
fix(ruby-ci): Redirect stderr to stdout for grep, bump version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -179,7 +179,7 @@ jobs:
         run: |
           gem install pkg/eppo-server-sdk-*.gem --verbose
           script="puts EppoClient::Core::Client.new(EppoClient::Config.new('placeholder'))"
-          ruby -reppo_client -e "$script" | grep 'fetching new configuration'
+          ruby -reppo_client -e "$script" 2>&1 | grep 'fetching new configuration'
           echo "✅ Successfully installed gem"
 
       - name: Set outputs

--- a/ruby-sdk/Cargo.lock
+++ b/ruby-sdk/Cargo.lock
@@ -304,7 +304,7 @@ dependencies = [
 
 [[package]]
 name = "eppo_client"
-version = "3.2.6"
+version = "3.2.7"
 dependencies = [
  "env_logger",
  "eppo_core",

--- a/ruby-sdk/Gemfile.lock
+++ b/ruby-sdk/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    eppo-server-sdk (3.2.6)
+    eppo-server-sdk (3.2.7)
       rb_sys (~> 0.9.102)
 
 GEM

--- a/ruby-sdk/ext/eppo_client/Cargo.toml
+++ b/ruby-sdk/ext/eppo_client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "eppo_client"
 # TODO: this version and lib/eppo_client/version.rb should be in sync
-version = "3.2.6"
+version = "3.2.7"
 edition = "2021"
 license = "MIT"
 publish = false

--- a/ruby-sdk/lib/eppo_client/version.rb
+++ b/ruby-sdk/lib/eppo_client/version.rb
@@ -2,5 +2,5 @@
 
 # TODO: this version and ext/eppo_client/Cargo.toml should be in sync
 module EppoClient
-  VERSION = "3.2.6"
+  VERSION = "3.2.7"
 end


### PR DESCRIPTION
Looks like we're logging to stderr so grep is not finding out logs. 

Verified this locally:

<img width="997" alt="image" src="https://github.com/user-attachments/assets/b750c3d3-fa3d-440d-8187-31e6c36a4c10">
