### PR TITLE
bump rubocop to 1.67; removes rexml vulnerability (dependabot-6)

### DIFF
--- a/ruby-sdk/Gemfile
+++ b/ruby-sdk/Gemfile
@@ -13,5 +13,5 @@ group :development do
   gem "rake", "~> 13.0"
   gem "rake-compiler"
   gem "rb_sys", "~> 0.9.102"
-  gem "rubocop", "~> 1.21"
+  gem "rubocop", "~> 1.67"
 end

--- a/ruby-sdk/Gemfile.lock
+++ b/ruby-sdk/Gemfile.lock
@@ -11,19 +11,17 @@ GEM
     diff-lcs (1.5.1)
     json (2.7.2)
     language_server-protocol (3.17.0.3)
-    parallel (1.25.1)
-    parser (3.3.3.0)
+    parallel (1.26.3)
+    parser (3.3.5.0)
       ast (~> 2.4.1)
       racc
-    racc (1.8.0)
+    racc (1.8.1)
     rainbow (3.1.1)
     rake (13.2.1)
     rake-compiler (1.2.7)
       rake
     rb_sys (0.9.102)
     regexp_parser (2.9.2)
-    rexml (3.3.0)
-      strscan
     rspec (3.13.0)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
@@ -37,22 +35,20 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
     rspec-support (3.13.1)
-    rubocop (1.64.1)
+    rubocop (1.67.0)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
       parser (>= 3.3.0.2)
       rainbow (>= 2.2.2, < 4.0)
-      regexp_parser (>= 1.8, < 3.0)
-      rexml (>= 3.2.5, < 4.0)
-      rubocop-ast (>= 1.31.1, < 2.0)
+      regexp_parser (>= 2.4, < 3.0)
+      rubocop-ast (>= 1.32.2, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 3.0)
-    rubocop-ast (1.31.3)
+    rubocop-ast (1.32.3)
       parser (>= 3.3.1.0)
     ruby-progressbar (1.13.0)
-    strscan (3.1.0)
-    unicode-display_width (2.5.0)
+    unicode-display_width (2.6.0)
 
 PLATFORMS
   ruby
@@ -63,7 +59,7 @@ DEPENDENCIES
   rake-compiler
   rb_sys (~> 0.9.102)
   rspec (~> 3.0)
-  rubocop (~> 1.21)
+  rubocop (~> 1.67)
 
 BUNDLED WITH
    2.4.4


### PR DESCRIPTION
## Observation

* https://github.com/Eppo-exp/rust-sdk/security/dependabot/4
* https://github.com/Eppo-exp/rust-sdk/security/dependabot/5
* https://github.com/Eppo-exp/rust-sdk/security/dependabot/6

<img width="1596" alt="Screenshot 2024-10-22 at 10 55 43 AM" src="https://github.com/user-attachments/assets/f9646feb-def1-4230-941c-9347602aec6a">

## Changes

rubocop removes `rexml` dependency in `1.66` (https://github.com/rubocop/rubocop/blob/7b6fdc6f24022e62cb2591f0fab932587da2d9b1/relnotes/v1.66.0.md?plain=1#L45)

Bumped to `1.67` to remove `rexml` from our lockfile.