### PR TITLE
fix(ruby): `eppo_client` shared lib should be under `lib/eppo_client`

### DIFF
--- a/ruby-sdk/Cargo.lock
+++ b/ruby-sdk/Cargo.lock
@@ -304,7 +304,7 @@ dependencies = [
 
 [[package]]
 name = "eppo_client"
-version = "3.2.7"
+version = "3.2.8"
 dependencies = [
  "env_logger",
  "eppo_core",

--- a/ruby-sdk/Gemfile.lock
+++ b/ruby-sdk/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    eppo-server-sdk (3.2.7)
+    eppo-server-sdk (3.2.8)
       rb_sys (~> 0.9.102)
 
 GEM

--- a/ruby-sdk/ext/eppo_client/Cargo.toml
+++ b/ruby-sdk/ext/eppo_client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "eppo_client"
 # TODO: this version and lib/eppo_client/version.rb should be in sync
-version = "3.2.7"
+version = "3.2.8"
 edition = "2021"
 license = "MIT"
 publish = false

--- a/ruby-sdk/ext/eppo_client/extconf.rb
+++ b/ruby-sdk/ext/eppo_client/extconf.rb
@@ -3,4 +3,4 @@
 require "mkmf"
 require "rb_sys/mkmf"
 
-create_rust_makefile("eppo_client")
+create_rust_makefile("eppo_client/eppo_client")

--- a/ruby-sdk/lib/eppo_client/version.rb
+++ b/ruby-sdk/lib/eppo_client/version.rb
@@ -2,5 +2,5 @@
 
 # TODO: this version and ext/eppo_client/Cargo.toml should be in sync
 module EppoClient
-  VERSION = "3.2.7"
+  VERSION = "3.2.8"
 end


### PR DESCRIPTION
## Description 

In environments for which we don't have prebuilt binaries of the shared eppo client lib, it's built upon running `gem install`, however the resulting file was being placed in the wrong directory.

We want it under `lib/eppo_client/` instead, so that `require_relative 'eppo_client'` works at https://github.com/Eppo-exp/rust-sdk/blob/main/ruby-sdk/lib/eppo_client/client.rb#L13

## Testing

Tested with a docker container.
Dockerfile:
```
# Use the official Ruby 4.3 image as a base
FROM ruby:3.3

# Set working directory in container
WORKDIR /app

RUN apt-get update && apt-get install -y \
    git \
    build-essential \
    curl \
    clang \
    libclang-dev \
    && rm -rf /var/lib/apt/lists/*

RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
ENV PATH="/root/.cargo/bin:${PATH}"

# Copy your Gemfile and Gemfile.lock to install dependencies
COPY Gemfile Gemfile.lock ./

RUN bundle config force_ruby_platform true

# Install gems with Bundler
RUN bundle install

# Copy your test script into the container
COPY test_script.rb /app/test_script.rb


# Make test_script.rb executable (if necessary)
RUN chmod +x /app/test_script.rb

# Set the default command to run the test script
CMD ["bundle", "exec", "ruby", "/app/test_script.rb"]
```

Gemfile
```
source 'https://rubygems.org'

gem 'eppo-server-sdk', git: 'https://github.com/Eppo-exp/rust-sdk.git', ref: '776f7a3eba98be668bd7a34bd7070aed9c74d6e4', glob: 'ruby-sdk/*.gemspec'
```

test_script.rb
```ruby
require 'eppo_client'

def hello_eppo
  EppoClient.init(EppoClient::Config.new('placeholder-api-key'))

  EppoClient::Client.instance.get_string_assignment('a', 'b', {}, 'fallback')

  puts "hooray"
end

if __FILE__ == $0
  hello_eppo
end
```

```
$ docker build -t ruby_gem_test .
$ docker run --rm ruby_gem_test                                                                                                                                                                                                                                                                     /usr/local/bundle/bundler/gems/rust-sdk-776f7a3eba98/ruby-sdk/lib/eppo_client.rb:3: warning: logger was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add logger to your Gemfile or gemspec to silence this warning.
[2024-10-30T22:28:02Z DEBUG eppo] fetching new configuration
[2024-10-30T22:28:02Z WARN  eppo] evaluating a flag before Eppo configuration has been fetched flag_key=a subject_key=b
[2024-10-30T22:28:02Z DEBUG eppo] fetching UFC flags configuration
hooray
```

<img width="719" alt="image" src="https://github.com/user-attachments/assets/d0e18ccd-f634-419e-8199-ccd2673c202d">
