### PR TITLE
feat(rust): add wait_for_configuration_timeout() method

### DIFF
--- a/.changeset/tall-days-film.md
+++ b/.changeset/tall-days-film.md
@@ -1,0 +1,8 @@
+---
+"eppo_core": minor
+"rust-sdk": minor
+---
+
+Add `wait_for_configuration_timeout()` method.
+
+In poor network conditions, `wait_for_configuration()` may block waiting on configuration indefinitely which may be undesired. Add a new `wait_for_configuration_timeout()` which allows specifying a timeout for waiting.

--- a/eppo_core/src/error.rs
+++ b/eppo_core/src/error.rs
@@ -41,6 +41,9 @@ pub enum Error {
     /// Network error.
     #[error(transparent)]
     Network(Arc<reqwest::Error>),
+
+    #[error("timed out waiting for operation")]
+    Timeout,
 }
 
 impl From<std::io::Error> for Error {

--- a/rust-sdk/Cargo.toml
+++ b/rust-sdk/Cargo.toml
@@ -14,6 +14,7 @@ rust-version = "1.80.0"
 eppo_core = { version = "=9.2.0", path = "../eppo_core" }
 log = { version = "0.4.21", features = ["kv", "kv_serde"] }
 serde_json = "1.0.116"
+tokio = { version = "1.34.0", default-features = false, features = ["time"] }
 
 [[example]]
 name = "simple"

--- a/rust-sdk/README.md
+++ b/rust-sdk/README.md
@@ -38,7 +38,9 @@ Initialize an instance of Eppo's client. Once initialized, the client can be use
 use eppo::ClientConfig;
 
 let mut client = ClientConfig::from_api_key("api-key").to_client();
-client.start_poller_thread();
+let thread = client.start_poller_thread();
+
+thread.wait_for_configuration_timeout(std::time::Duration::from_secs(5));
 ```
 
 ### Assign Anywhere

--- a/rust-sdk/examples/assignment_details/main.rs
+++ b/rust-sdk/examples/assignment_details/main.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 use eppo::AttributeValue;
 
@@ -19,7 +19,7 @@ pub fn main() -> eppo::Result<()> {
 
     // Block waiting for configuration. Until this call returns, the client will return None for all
     // assignments.
-    if let Err(err) = poller.wait_for_configuration() {
+    if let Err(err) = poller.wait_for_configuration_timeout(Duration::from_secs(5)) {
         println!("error requesting configuration: {:?}", err);
     }
 

--- a/rust-sdk/examples/simple/main.rs
+++ b/rust-sdk/examples/simple/main.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, time::Duration};
 
 pub fn main() -> eppo::Result<()> {
     // Configure env_logger to see Eppo SDK logs.
@@ -17,7 +17,7 @@ pub fn main() -> eppo::Result<()> {
 
     // Block waiting for configuration. Until this call returns, the client will return None for all
     // assignments.
-    if let Err(err) = poller.wait_for_configuration() {
+    if let Err(err) = poller.wait_for_configuration_timeout(Duration::from_secs(5)) {
         println!("error requesting configuration: {:?}", err);
     }
 

--- a/rust-sdk/src/client.rs
+++ b/rust-sdk/src/client.rs
@@ -21,7 +21,8 @@ use eppo_core::{
 ///
 /// Before calling `Client::get_assignment()`, you should start the poller thread by calling
 /// [`Client::start_poller_thread()`], ensuring that the configuration is fetched. It's also
-/// recommended to call [`PollerThread::wait_for_configuration`] before calling `get_assignment()`.
+/// recommended to call [`PollerThread::wait_for_configuration_timeout()`] before calling
+/// `get_assignment()`.
 ///
 /// The reason the poller thread is not started automatically is to allow SDK extension to support
 /// `async` configuration fetching in the future (using async Rust runtimes).
@@ -73,7 +74,7 @@ impl<'a> Client<'a> {
     /// `get_assignment()`. Otherwise, the client will always return `None`.
     ///
     /// It is recommended to wait for the Eppo configuration to get fetched with
-    /// [`PollerThread::wait_for_configuration()`].
+    /// [`PollerThread::wait_for_configuration_timeout()`].
     ///
     /// # Typed versions
     ///
@@ -127,7 +128,7 @@ impl<'a> Client<'a> {
     /// `get_string_assignment()`. Otherwise, the client will always return `None`.
     ///
     /// It is recommended to wait for the Eppo configuration to get fetched with
-    /// [`PollerThread::wait_for_configuration()`].
+    /// [`PollerThread::wait_for_configuration_timeout()`].
     ///
     /// # Examples
     ///
@@ -170,7 +171,7 @@ impl<'a> Client<'a> {
     /// `get_integer_assignment()`. Otherwise, the client will always return `None`.
     ///
     /// It is recommended to wait for the Eppo configuration to get fetched with
-    /// [`PollerThread::wait_for_configuration()`].
+    /// [`PollerThread::wait_for_configuration_timeout()`].
     ///
     /// # Examples
     ///
@@ -213,7 +214,7 @@ impl<'a> Client<'a> {
     /// `get_numeric_assignment()`. Otherwise, the client will always return `None`.
     ///
     /// It is recommended to wait for the Eppo configuration to get fetched with
-    /// [`PollerThread::wait_for_configuration()`].
+    /// [`PollerThread::wait_for_configuration_timeout()`].
     ///
     /// # Examples
     ///
@@ -256,7 +257,7 @@ impl<'a> Client<'a> {
     /// `get_boolean_assignment()`. Otherwise, the client will always return `None`.
     ///
     /// It is recommended to wait for the Eppo configuration to get fetched with
-    /// [`PollerThread::wait_for_configuration()`].
+    /// [`PollerThread::wait_for_configuration_timeout()`].
     ///
     /// # Examples
     ///
@@ -299,7 +300,7 @@ impl<'a> Client<'a> {
     /// `get_json_assignment()`. Otherwise, the client will always return `None`.
     ///
     /// It is recommended to wait for the Eppo configuration to get fetched with
-    /// [`PollerThread::wait_for_configuration()`].
+    /// [`PollerThread::wait_for_configuration_timeout()`].
     ///
     /// # Examples
     ///


### PR DESCRIPTION
Add `wait_for_configuration_timeout()` method.

In poor network conditions, `wait_for_configuration()` may block waiting on configuration indefinitely which may be undesired. Add a new `wait_for_configuration_timeout()` which allows specifying a timeout for waiting.

It used to be hard to implement because we didn't have shared async runtime (that's why we had indefinitely-blocking version initially). But now we have a shared async runtime, so handling timeouts is easier.