### PR TITLE
fix(FFESUPPORT-891): remediate July 2026 dependabot vulnerabilities

### DIFF
--- a/.changeset/july-2026-security-deps.md
+++ b/.changeset/july-2026-security-deps.md
@@ -1,0 +1,9 @@
+---
+"eppo_core": patch
+"elixir-sdk": patch
+"python-sdk": patch
+"ruby-sdk": patch
+"rust-sdk": patch
+---
+
+Security: update dependencies to patched versions (July 2026 Dependabot advisories). Bumps `pyo3` 0.27 → 0.29 (python-sdk / eppo_core's optional `pyo3` feature; raises that build's MSRV to 1.83) and `serde_with` 3.20 → 3.21 (ruby-sdk / elixir-sdk). No public API changes.

--- a/elixir-sdk/Cargo.lock
+++ b/elixir-sdk/Cargo.lock
@@ -1346,9 +1346,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.20.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
 dependencies = [
  "base64",
  "bs58",
@@ -1362,9 +1362,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.20.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac"
+checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/eppo_core/Cargo.toml
+++ b/eppo_core/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/Eppo-exp/rust-sdk"
 license = "MIT"
 keywords = ["eppo", "feature-flags"]
 categories = ["config"]
-rust-version = "1.80.0"
+rust-version = "1.83.0" # raised from 1.80: pyo3 0.29 (optional `pyo3` feature) requires Rust >= 1.83
 
 [features]
 # Use ahash for HashMaps. This is currently disabled by default to

--- a/eppo_core/Cargo.toml
+++ b/eppo_core/Cargo.toml
@@ -51,7 +51,7 @@ uuid = { version = "1.11.0", features = ["v4", "serde"], optional = true }
 exponential-backoff = { version = "2.0.0", optional = true }
 
 # pyo3 dependencies
-pyo3 = { version = "0.27.0", optional = true, default-features = false }
+pyo3 = { version = "0.29", optional = true, default-features = false }
 serde-pyobject = { version = "0.8.0", optional = true }
 
 # magnus dependencies

--- a/eppo_core/src/attributes/context_attributes.rs
+++ b/eppo_core/src/attributes/context_attributes.rs
@@ -15,7 +15,7 @@ use super::{
 // it and make it an internal type.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[cfg_attr(feature = "pyo3", pyo3::pyclass(module = "eppo_client"))]
+#[cfg_attr(feature = "pyo3", pyo3::pyclass(module = "eppo_client", from_py_object))]
 pub struct ContextAttributes {
     /// Numeric attributes are quantitative (e.g., real numbers) and define a scale.
     ///

--- a/package-lock.json
+++ b/package-lock.json
@@ -512,17 +512,6 @@
       "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
       "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ=="
     },
-    "node_modules/@types/node": {
-      "version": "25.0.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.3.tgz",
-      "integrity": "sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "undici-types": "~7.16.0"
-      }
-    },
     "node_modules/agent-base": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
@@ -1328,16 +1317,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -1588,9 +1577,10 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
       },
@@ -2003,9 +1993,10 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
     "node_modules/joi": {
-      "version": "17.13.3",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.3.tgz",
-      "integrity": "sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==",
+      "version": "17.13.4",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.4.tgz",
+      "integrity": "sha512-1RuuER6kmt8K8I3nIWvPZKi5RQCb568ZPyY4Pwjlua+yo+63ZTmIwxLZH0heBmiKN4uxjvCiarDrjaeH84xicQ==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "@hapi/hoek": "^9.3.0",
         "@hapi/topo": "^5.1.0",
@@ -2015,9 +2006,19 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -2763,9 +2764,9 @@
       }
     },
     "node_modules/read-yaml-file/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
@@ -2986,9 +2987,13 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.1.tgz",
-      "integrity": "sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.10.0.tgz",
+      "integrity": "sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -3412,14 +3417,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/undici-types": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/union": {
       "version": "0.5.0",

--- a/python-sdk/Cargo.toml
+++ b/python-sdk/Cargo.toml
@@ -10,7 +10,7 @@ crate-type = ["cdylib"]
 [dependencies]
 eppo_core = { version = "=10.0.0", path = "../eppo_core", features = ["pyo3", "ahash"] }
 log = "0.4.22"
-pyo3 = "0.27.2"
-pyo3-log = "0.13.2"
+pyo3 = "0.29"
+pyo3-log = "0.13.4"
 serde-pyobject = "0.8.0"
 serde_json = "1.0.125"

--- a/python-sdk/src/assignment_logger.rs
+++ b/python-sdk/src/assignment_logger.rs
@@ -2,7 +2,7 @@ use pyo3::prelude::*;
 use pyo3::types::PyDict;
 
 #[derive(Debug, Clone)]
-#[pyclass(frozen, subclass, module = "eppo_client")]
+#[pyclass(frozen, subclass, module = "eppo_client", from_py_object)]
 pub struct AssignmentLogger {}
 
 #[pymethods]

--- a/ruby-sdk/Cargo.lock
+++ b/ruby-sdk/Cargo.lock
@@ -1686,9 +1686,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.20.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e72c1c2cb7b223fafb600a619537a871c2818583d619401b785e7c0b746ccde2"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
 dependencies = [
  "base64",
  "bs58",
@@ -1702,9 +1702,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.20.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b90c488738ecb4fb0262f41f43bc40efc5868d9fb744319ddf5f5317f417bfac"
+checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
 dependencies = [
  "darling",
  "proc-macro2",


### PR DESCRIPTION
🤖 **Generated from Claude**

Remediates the 11 open Dependabot alerts in `eppo-multiplatform` across the Rust workspaces and npm tooling. Jira: https://datadoghq.atlassian.net/browse/FFESUPPORT-891

## Advisories closed
| Advisory | Severity | Package | Before → After | Where |
|---|---|---|---|---|
| shell-quote | **critical** | shell-quote | 1.8.1 → **1.10.0** | npm (dev tooling) |
| form-data | high | form-data | 4.0.5 → **4.0.6** | npm |
| GHSA-h67p-54hq-rp68 | medium | js-yaml | 4.1.1 → **4.3.0** · 3.14.2 → **3.15.0** | npm |
| joi | medium | joi | 17.13.3 → **17.13.4** | npm |
| serde_with | medium | serde_with | 3.20.0 → **3.21.0** | Rust (ruby-sdk, elixir-sdk) |
| pyo3 (×2) | high+med | pyo3 | 0.27 → **0.29** | Rust (eppo_core, python-sdk) |

## Approach
- **pyo3 0.27 → 0.29** (the risky one): the code already uses the modern `Bound`/`into_pyobject` API, so the migration was just the version bump + `pyo3-log 0.13.2 → 0.13.4` (0.13.2 capped at `<0.28`) + an explicit **`from_py_object`** opt-in on the two `#[pyclass]` `Clone` types (`ContextAttributes`, `AssignmentLogger`) — pyo3 0.29 makes that derive opt-in, and I kept the existing behavior. `serde-pyobject 0.8.0` already allows pyo3 `>=0.27`, so no change there.
- **serde_with** 3.20 → 3.21: in-range minor across the ruby/elixir Cargo.locks.
- **npm**: lockfile-only re-resolution of the four dev-tooling transitives (`package.json` unchanged). The root `Cargo.lock` is gitignored, so the Rust fixes ride on the `Cargo.toml` bumps (CI regenerates the lock).

## How the tests/CI protect this change
- `cargo check --workspace` ✓; **`cargo test -p eppo_core` (pyo3 feature) → 57 tests pass**; `cargo build -p eppo_py` (Python extension) ✓.
- `npm update` reports **0 vulnerabilities**.
- CI runs `cargo test --workspace --all-features` plus the Python (maturin + pytest), Ruby, and Elixir SDK suites — which exercise the pyo3 bindings end-to-end.

## Deferred advisories
None — all 11 alerts addressed; none left dismissed/auto-dismissed.
