### PR TITLE
fix(FFESUPPORT-891): re-resolve axios + brace-expansion to patched versions (Vanta 2026-07)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -641,9 +641,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
-      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
+      "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.16.0",
@@ -686,9 +686,9 @@
       "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",


### PR DESCRIPTION
🤖 **Generated from Claude**

Resolves the July 2026 Vanta/Dependabot supplement for **eppo-multiplatform** — [FFESUPPORT-891](https://datadoghq.atlassian.net/browse/FFESUPPORT-891).

## What & why
After the prior July sweep (#420), two advisories remained, both **transitive dev-tooling** deps in the root `package-lock.json` (the monorepo's test-orchestration tooling — `start-server-and-test` → `wait-on`). Nothing ships in any SDK crate/package.

| Package | Advisory | Before → After |
| --- | --- | --- |
| axios | GHSA-gcfj-64vw-6mp9 + 9 others (`< 1.18.0`) | 1.16.1 → 1.18.1 |
| brace-expansion | GHSA-3jxr-9vmj-r5cp / CVE-2026-13149 (`< 1.1.16`) | 1.1.14 → 1.1.16 |

Fix is a **lockfile-only re-resolution** (`npm update axios brace-expansion`). axios resolves within `wait-on`'s declared `^1.6.1`; brace-expansion is a deep transitive. No `package.json` change, no override.

## Why no changeset
This touches only root dev-tooling in `package-lock.json` — no published package (`eppo_core`, `python-sdk`, `ruby-sdk`, `elixir-sdk`, `rust-sdk`) changes, so there is nothing to version/release. The `Prepare release` workflow runs only on push to `main` and gates on shipped-package changes.

## How tests/CI protect this change
`npm install` is clean and idempotent, `npm audit` reports 0 vulnerabilities, and the tooling (`wait-on`, `start-server-and-test`) loads correctly with axios 1.18.1. CI's `npm run test` uses exactly this tooling to spin up the mock-server and run the Rust/Python/Ruby/Elixir suites — a working test run is the safety net.

## Deferred / out of scope
None — these were the only open advisories for this repo.