### PR TITLE
Split changeset entries for pyo3 and serde_with updates

### DIFF
--- a/.changeset/july-2026-security-deps.md
+++ b/.changeset/july-2026-security-deps.md
@@ -1,9 +1,6 @@
 ---
-"eppo_core": patch
 "elixir-sdk": patch
-"python-sdk": patch
 "ruby-sdk": patch
-"rust-sdk": patch
 ---
 
-Security: update dependencies to patched versions (July 2026 Dependabot advisories). Bumps `pyo3` 0.27 → 0.29 (python-sdk / eppo_core's optional `pyo3` feature; raises that build's MSRV to 1.83) and `serde_with` 3.20 → 3.21 (ruby-sdk / elixir-sdk). No public API changes.
+Update `serde_with` 3.20 → 3.21.

--- a/.changeset/stale-melons-eat.md
+++ b/.changeset/stale-melons-eat.md
@@ -1,0 +1,6 @@
+---
+"eppo_core": major
+"python-sdk": patch
+---
+
+Update pyo3 from 0.27 to 0.29. Raises MSRV to 1.83.

--- a/eppo_core/Cargo.toml
+++ b/eppo_core/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/Eppo-exp/rust-sdk"
 license = "MIT"
 keywords = ["eppo", "feature-flags"]
 categories = ["config"]
-rust-version = "1.83.0" # raised from 1.80: pyo3 0.29 (optional `pyo3` feature) requires Rust >= 1.83
+rust-version = "1.83.0"
 
 [features]
 # Use ahash for HashMaps. This is currently disabled by default to


### PR DESCRIPTION
Follow up for https://github.com/Eppo-exp/eppo-multiplatform/pull/420
