### PR TITLE
ci: fix version workflow

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -38,7 +38,14 @@ jobs:
         run: rustup update stable && rustup default stable
 
       - name: Install cargo-edit
-        run: cargo install cargo-edit
+        run: cargo install cargo-edit@0.13.13
+
+      # So cargo-edit sees correct version of eppo_core inside nested workspaces
+      - name: Override eppo_core
+        run: |
+          mkdir -p ~/.cargo/
+          echo "[patch.crates-io.eppo_core]" >> "${CARGO_HOME:-$HOME/.cargo}/config.toml"
+          echo "path = '$PWD/eppo_core'" >> "${CARGO_HOME:-$HOME/.cargo}/config.toml"
 
       - name: Create Version Pull Request
         uses: changesets/action@v1

--- a/elixir-sdk/postversion.sh
+++ b/elixir-sdk/postversion.sh
@@ -5,4 +5,5 @@ VERSION="$(jq -r .version ./package.json)"
 
 (cd native/sdk_core && cargo set-version -p sdk_core "$VERSION")
 
-sed -e "s/\\(^ *version:\\).*/\1 \"$VERSION\",/" -i mix.exs
+sed -e "s/\\(^ *version:\\).*/\1 \"$VERSION\",/" mix.exs > mix.exs.tmp
+mv mix.exs.tmp mix.exs

--- a/ruby-sdk/postversion.sh
+++ b/ruby-sdk/postversion.sh
@@ -6,4 +6,5 @@ VERSION="$(jq -r .version ./package.json)"
 cargo set-version -p eppo_client "$VERSION"
 
 # Update VERSION in version.rb
-sed -e "s/VERSION = \".*\"/VERSION = \"$VERSION\"/" -i ./lib/eppo_client/version.rb
+sed -e "s/VERSION = \".*\"/VERSION = \"$VERSION\"/" ./lib/eppo_client/version.rb > ./lib/eppo_client/version.rb.tmp
+mv ./lib/eppo_client/version.rb.tmp ./lib/eppo_client/version.rb


### PR DESCRIPTION
version workflow is failing with the following error:

    > ruby-sdk@3.8.1 postversion
    > ./postversion.sh

    + jq -r .version ./package.json
    + VERSION=3.8.1
    + cargo set-version -p eppo_client 3.8.1
    Error: `cargo metadata` exited with an error:     Updating crates.io index
    error: failed to select a version for the requirement `eppo_core = "=10.0.1"`
    candidate versions found which didn't match: 10.0.0, 9.3.0, 9.2.0, ...

This is likely caused by cargo not finding the eppo_core inside ruby workspace.

Set the eppo_core override in ~/.cargo/config.toml.

Additional fixes:
- pin cargo-edit to a specific version
- replace sed's -i option with manual handling of tmp file to make it portable across linux and macos
